### PR TITLE
doc: fix typo of lib name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [stringcast-rust][repo-url] [![crate.io][crateio-img]][crateio-url] [![doc.rs][docrs-img]][docrs-url] [![CI Status][ci-img]][ci-url] [![MIT License][mit-img]][mit-url]
+# [stringcase-rust][repo-url] [![crate.io][crateio-img]][crateio-url] [![doc.rs][docrs-img]][docrs-url] [![CI Status][ci-img]][ci-url] [![MIT License][mit-img]][mit-url]
 
 This library provides some functions that convert string cases between camelCase, COBOL-CASE, kebab-case, MACRO_CASE, PascalCase, snake_case and Train-Case.
 


### PR DESCRIPTION
`stringcas[t]-rust` --> `stringcas[e]-rust`