### PR TITLE
chore: modified build.sh about cover and bench

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,12 +33,12 @@ unit() {
 }
 
 cover() {
-  cargo llvm-cov
+  cargo llvm-cov --html
   errcheck $?
 }
 
 bench() {
-  cargo bench --quiet -- $1
+  cargo +nightly bench --quiet -- $1
   errcheck $?
 }
 


### PR DESCRIPTION
This PR makes `build.sh` output coverage results to html file and possible to run benchmark without changing `rustup default` to `nightly`.