### PR TITLE
refactor: made use enum instead of u8 flag

### DIFF
--- a/benches/camel_case_bench.rs
+++ b/benches/camel_case_bench.rs
@@ -2,7 +2,7 @@
 
 extern crate test;
 
-use stringcase::{camel_case, camel_case_with_sep, camel_case_with_keep};
+use stringcase::{camel_case, camel_case_with_keep, camel_case_with_sep};
 use test::Bencher;
 
 #[bench]

--- a/benches/cobol_case_bench.rs
+++ b/benches/cobol_case_bench.rs
@@ -2,7 +2,7 @@
 
 extern crate test;
 
-use stringcase::{cobol_case, cobol_case_with_sep, cobol_case_with_keep};
+use stringcase::{cobol_case, cobol_case_with_keep, cobol_case_with_sep};
 use test::Bencher;
 
 #[bench]

--- a/benches/kebab_case_bench.rs
+++ b/benches/kebab_case_bench.rs
@@ -2,7 +2,7 @@
 
 extern crate test;
 
-use stringcase::{kebab_case, kebab_case_with_sep, kebab_case_with_keep};
+use stringcase::{kebab_case, kebab_case_with_keep, kebab_case_with_sep};
 use test::Bencher;
 
 #[bench]

--- a/benches/macro_case_bench.rs
+++ b/benches/macro_case_bench.rs
@@ -2,7 +2,7 @@
 
 extern crate test;
 
-use stringcase::{macro_case, macro_case_with_sep, macro_case_with_keep};
+use stringcase::{macro_case, macro_case_with_keep, macro_case_with_sep};
 use test::Bencher;
 
 #[bench]

--- a/benches/pascal_case_bench.rs
+++ b/benches/pascal_case_bench.rs
@@ -2,7 +2,7 @@
 
 extern crate test;
 
-use stringcase::{pascal_case, pascal_case_with_sep, pascal_case_with_keep};
+use stringcase::{pascal_case, pascal_case_with_keep, pascal_case_with_sep};
 use test::Bencher;
 
 #[bench]

--- a/benches/snake_case_test.rs
+++ b/benches/snake_case_test.rs
@@ -2,7 +2,7 @@
 
 extern crate test;
 
-use stringcase::{snake_case, snake_case_with_sep, snake_case_with_keep};
+use stringcase::{snake_case, snake_case_with_keep, snake_case_with_sep};
 use test::Bencher;
 
 #[bench]

--- a/benches/train_case_test.rs
+++ b/benches/train_case_test.rs
@@ -2,7 +2,7 @@
 
 extern crate test;
 
-use stringcase::{train_case, train_case_with_sep, train_case_with_keep};
+use stringcase::{train_case, train_case_with_keep, train_case_with_sep};
 use test::Bencher;
 
 #[bench]

--- a/src/camel_case.rs
+++ b/src/camel_case.rs
@@ -20,11 +20,11 @@ pub fn camel_case(input: &str) -> String {
     // .len returns byte count but ok in this case!
 
     enum ChIs {
-      FirstOfStr,
-      InFirstWord,
-      NextOfUpper,
-      NextOfMark,
-      Others,
+        FirstOfStr,
+        InFirstWord,
+        NextOfUpper,
+        NextOfMark,
+        Others,
     }
 
     let mut flag = ChIs::FirstOfStr;
@@ -100,11 +100,11 @@ pub fn camel_case_with_sep(input: &str, seps: &str) -> String {
     // .len returns byte count but ok in this case!
 
     enum ChIs {
-      FirstOfStr,
-      InFirstWord,
-      NextOfUpper,
-      NextOfMark,
-      Others,
+        FirstOfStr,
+        InFirstWord,
+        NextOfUpper,
+        NextOfMark,
+        Others,
     }
     let mut flag = ChIs::FirstOfStr;
 

--- a/src/camel_case.rs
+++ b/src/camel_case.rs
@@ -19,57 +19,61 @@ pub fn camel_case(input: &str) -> String {
     let mut result = String::with_capacity(input.len());
     // .len returns byte count but ok in this case!
 
-    let mut flag: u8 = 0;
-    // 0: first char
-    // 1: char in first word
-    // 2: previous char is upper
-    // 3: previous char is mark
-    // 4: other
+    enum ChIs {
+      FirstOfStr,
+      InFirstWord,
+      NextOfUpper,
+      NextOfMark,
+      Others,
+    }
+
+    let mut flag = ChIs::FirstOfStr;
 
     for ch in input.chars() {
         if ch.is_ascii_uppercase() {
             match flag {
-                0 | 1 => {
-                    flag = 1;
+                ChIs::FirstOfStr | ChIs::InFirstWord => {
                     result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::InFirstWord;
                 }
-                2 => {
-                    flag = 2;
+                ChIs::NextOfUpper => {
                     result.push(ch.to_ascii_lowercase());
+                    //flag = ChIs::NextOfUpper;
                 }
                 _ => {
-                    flag = 2;
                     result.push(ch);
+                    flag = ChIs::NextOfUpper
                 }
             }
         } else if ch.is_ascii_lowercase() {
             match flag {
-                2 => match result.pop() {
+                ChIs::NextOfUpper => match result.pop() {
                     Some(prev) => {
-                        flag = 4;
                         result.push(prev.to_ascii_uppercase());
                         result.push(ch);
+                        flag = ChIs::Others;
                     }
                     None => (), // impossible
                 },
-                3 => {
-                    flag = 2;
+                ChIs::NextOfMark => {
                     result.push(ch.to_ascii_uppercase());
+                    flag = ChIs::NextOfUpper;
                 }
                 _ => {
-                    flag = 4;
                     result.push(ch);
+                    flag = ChIs::Others;
                 }
             }
         } else if ch.is_ascii_digit() {
-            match flag {
-                3 => flag = 2,
-                _ => flag = 4,
-            }
             result.push(ch);
+            match flag {
+                ChIs::NextOfMark => flag = ChIs::NextOfUpper,
+                _ => flag = ChIs::Others,
+            }
         } else {
-            if flag != 0 {
-                flag = 3;
+            match flag {
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfMark,
             }
         }
     }
@@ -95,61 +99,64 @@ pub fn camel_case_with_sep(input: &str, seps: &str) -> String {
     let mut result = String::with_capacity(input.len());
     // .len returns byte count but ok in this case!
 
-    let mut flag: u8 = 0;
-    // 0: first char
-    // 1: char in first word
-    // 2: previous char is upper
-    // 3: previous char is mark
-    // 4: other
+    enum ChIs {
+      FirstOfStr,
+      InFirstWord,
+      NextOfUpper,
+      NextOfMark,
+      Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
 
     for ch in input.chars() {
         if seps.contains(ch) {
-            if flag != 0 {
-                flag = 3;
+            match flag {
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfMark,
             }
         } else if ch.is_ascii_uppercase() {
             match flag {
-                0 | 1 => {
-                    flag = 1;
+                ChIs::FirstOfStr | ChIs::InFirstWord => {
                     result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::InFirstWord;
                 }
-                2 => {
-                    flag = 2;
+                ChIs::NextOfUpper => {
                     result.push(ch.to_ascii_lowercase());
+                    //flag = ChIs::NextOfUpper;
                 }
                 _ => {
-                    flag = 2;
                     result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
             }
         } else if ch.is_ascii_lowercase() {
             match flag {
-                2 => match result.pop() {
+                ChIs::NextOfUpper => match result.pop() {
                     Some(prev) => {
-                        flag = 4;
                         result.push(prev.to_ascii_uppercase());
                         result.push(ch);
+                        flag = ChIs::Others;
                     }
                     None => (), // impossible
                 },
-                3 => {
-                    flag = 2;
-                    result.push(ch.to_ascii_uppercase());
+                ChIs::NextOfMark => {
+                    result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
                 _ => {
-                    flag = 4;
                     result.push(ch);
+                    flag = ChIs::Others;
                 }
             }
         } else if ch.is_ascii_digit() {
+            result.push(ch);
             match flag {
-                3 => flag = 2,
-                _ => flag = 4,
+                ChIs::NextOfMark => flag = ChIs::NextOfUpper,
+                _ => flag = ChIs::Others,
             }
-            result.push(ch);
         } else {
-            flag = 3;
             result.push(ch);
+            flag = ChIs::NextOfMark;
         }
     }
 
@@ -175,60 +182,63 @@ pub fn camel_case_with_keep(input: &str, keeped: &str) -> String {
     let mut result = String::with_capacity(input.len());
     // .len returns byte count but ok in this case!
 
-    let mut flag: u8 = 0;
-    // 0: first char
-    // 1: char in first word
-    // 2: previous char is upper
-    // 3: previous char is mark
-    // 4: other
+    enum ChIs {
+        FirstOfStr,
+        InFirstWord,
+        NextOfUpper,
+        NextOfMark,
+        Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
 
     for ch in input.chars() {
         if ch.is_ascii_uppercase() {
             match flag {
-                0 | 1 => {
-                    flag = 1;
+                ChIs::FirstOfStr | ChIs::InFirstWord => {
+                    flag = ChIs::InFirstWord;
                     result.push(ch.to_ascii_lowercase());
                 }
-                2 => {
-                    flag = 2;
+                ChIs::NextOfUpper => {
                     result.push(ch.to_ascii_lowercase());
+                    //flag = ChIs::NextOfUpper;
                 }
                 _ => {
-                    flag = 2;
                     result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
             }
         } else if ch.is_ascii_lowercase() {
             match flag {
-                2 => match result.pop() {
+                ChIs::NextOfUpper => match result.pop() {
                     Some(prev) => {
-                        flag = 4;
                         result.push(prev.to_ascii_uppercase());
                         result.push(ch);
+                        flag = ChIs::Others;
                     }
                     None => (), // impossible
                 },
-                3 => {
-                    flag = 2;
+                ChIs::NextOfMark => {
                     result.push(ch.to_ascii_uppercase());
+                    flag = ChIs::NextOfUpper;
                 }
                 _ => {
-                    flag = 4;
                     result.push(ch);
+                    flag = ChIs::Others;
                 }
             }
         } else if ch.is_ascii_digit() {
+            result.push(ch);
             match flag {
-                3 => flag = 2,
-                _ => flag = 4,
+                ChIs::NextOfMark => flag = ChIs::NextOfUpper,
+                _ => flag = ChIs::Others,
             }
-            result.push(ch);
         } else if keeped.contains(ch) {
-            flag = 3;
             result.push(ch);
+            flag = ChIs::NextOfMark;
         } else {
-            if flag != 0 {
-                flag = 3;
+            match flag {
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfMark,
             }
         }
     }

--- a/src/camel_case.rs
+++ b/src/camel_case.rs
@@ -140,7 +140,7 @@ pub fn camel_case_with_sep(input: &str, seps: &str) -> String {
                     None => (), // impossible
                 },
                 ChIs::NextOfMark => {
-                    result.push(ch);
+                    result.push(ch.to_ascii_uppercase());
                     flag = ChIs::NextOfUpper;
                 }
                 _ => {

--- a/src/cobol_case.rs
+++ b/src/cobol_case.rs
@@ -19,47 +19,57 @@ pub fn cobol_case(input: &str) -> String {
     let mut result = String::with_capacity(input.len() + input.len() / 2);
     // .len returns byte count but ok in this case!
 
-    let mut flag: u8 = 0;
-    // 0: first char
-    // 1: previous char is upper
-    // 2: one and two chars before are upper
-    // 3: previous char is mark
-    // 4: other
+    enum ChIs {
+      FirstOfStr,
+      NextOfUpper,
+      NextOfContdUpper,
+      NextOfMark,
+      Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
 
     for ch in input.chars() {
         if ch.is_ascii_uppercase() {
             match flag {
-                0 => flag = 1,
-                1 | 2 => flag = 2,
+                ChIs::FirstOfStr => {
+                    result.push(ch);
+                    flag = ChIs::NextOfUpper;
+                },
+                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
+                    result.push(ch);
+                    flag = ChIs::NextOfContdUpper;
+                },
                 _ => {
-                    flag = 1;
                     result.push('-');
+                    result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
             }
-            result.push(ch);
         } else if ch.is_ascii_lowercase() {
             match flag {
-                2 => match result.pop() {
+                ChIs::NextOfContdUpper => match result.pop() {
                     Some(prev) => {
                         result.push('-');
                         result.push(prev);
                     }
                     None => (), // impossible
                 },
-                3 => result.push('-'),
+                ChIs::NextOfMark => result.push('-'),
                 _ => (),
             }
-            flag = 4;
             result.push(ch.to_ascii_uppercase());
+            flag = ChIs::Others;
         } else if ch.is_ascii_digit() {
-            if flag == 3 {
-                result.push('-');
+            match flag {
+              ChIs::NextOfMark => result.push('-'),
+              _ => (),
             }
-            flag = 4;
             result.push(ch);
+            flag = ChIs::Others;
         } else {
-            if flag != 0 {
-                flag = 3;
+            match flag {
+              ChIs::FirstOfStr => (),
+              _ => flag = ChIs::NextOfMark,
             }
         }
     }
@@ -85,56 +95,70 @@ pub fn cobol_case_with_sep(input: &str, seps: &str) -> String {
     let mut result = String::with_capacity(input.len() + input.len() / 2);
     // .len returns byte count but ok in this case!
 
-    let mut flag: u8 = 0;
-    // 0: first char
-    // 1: previous char is upper
-    // 2: one and two chars before are upper
-    // 3: previous char is mark (separator)
-    // 4: previous char is mark (keeped)
-    // 5: other
+    enum ChIs {
+      FirstOfStr,
+      NextOfUpper,
+      NextOfContdUpper,
+      NextOfSepMark,
+      NextOfKeepedMark,
+      Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
 
     for ch in input.chars() {
         if seps.contains(ch) {
-            if flag != 0 {
-                flag = 3;
+            match flag {
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfSepMark,
             }
         } else if ch.is_ascii_uppercase() {
             match flag {
-                0 => flag = 1,
-                1 | 2 => flag = 2,
+                ChIs::FirstOfStr => {
+                    result.push(ch);
+                    flag = ChIs::NextOfUpper;
+                },
+                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
+                    result.push(ch);
+                    flag = ChIs::NextOfContdUpper;
+                },
                 _ => {
-                    flag = 1;
                     result.push('-');
+                    result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
             }
-            result.push(ch);
         } else if ch.is_ascii_lowercase() {
             match flag {
-                2 => match result.pop() {
+                ChIs::NextOfContdUpper => match result.pop() {
                     Some(prev) => {
                         result.push('-');
                         result.push(prev);
                     }
                     None => (), // impossible
                 },
-                3 | 4 => result.push('-'),
+                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
+                    result.push('-');
+                },
                 _ => (),
             }
-            flag = 5;
             result.push(ch.to_ascii_uppercase());
+            flag = ChIs::Others;
         } else if ch.is_ascii_digit() {
             match flag {
-                3 | 4 => result.push('-'),
+                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
+                    result.push('-');
+                },
                 _ => (),
             }
-            flag = 5;
             result.push(ch);
+            flag = ChIs::Others;
         } else {
-            if flag == 3 {
-                result.push('-');
+            match flag {
+                ChIs::NextOfSepMark => result.push('-'),
+                _ => (),
             }
-            flag = 4;
             result.push(ch);
+            flag = ChIs::NextOfKeepedMark;
         }
     }
 
@@ -160,55 +184,69 @@ pub fn cobol_case_with_keep(input: &str, keeped: &str) -> String {
     let mut result = String::with_capacity(input.len() + input.len() / 2);
     // .len returns byte count but ok in this case!
 
-    let mut flag: u8 = 0;
-    // 0: first char
-    // 1: previous char is upper
-    // 2: one and two chars before are upper
-    // 3: previous char is mark (separator)
-    // 4: previous char is mark (keeped)
-    // 5: other
+    enum ChIs {
+      FirstOfStr,
+      NextOfUpper,
+      NextOfContdUpper,
+      NextOfSepMark,
+      NextOfKeepedMark,
+      Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
 
     for ch in input.chars() {
         if ch.is_ascii_uppercase() {
             match flag {
-                0 => flag = 1,
-                1 | 2 => flag = 2,
+                ChIs::FirstOfStr => {
+                    result.push(ch);
+                    flag = ChIs::NextOfUpper;
+                },
+                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
+                    result.push(ch);
+                    flag = ChIs::NextOfContdUpper;
+                },
                 _ => {
-                    flag = 1;
                     result.push('-');
-                }
+                    result.push(ch);
+                    flag = ChIs::NextOfUpper;
+                },
             }
-            result.push(ch);
         } else if ch.is_ascii_lowercase() {
             match flag {
-                2 => match result.pop() {
+                ChIs::NextOfContdUpper => match result.pop() {
                     Some(prev) => {
                         result.push('-');
                         result.push(prev);
                     }
                     None => (), // impossible
                 },
-                3 | 4 => result.push('-'),
+                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark  => {
+                    result.push('-');
+                },
                 _ => (),
             }
-            flag = 5;
             result.push(ch.to_ascii_uppercase());
+            flag = ChIs::Others;
         } else if ch.is_ascii_digit() {
             match flag {
-                3 | 4 => result.push('-'),
+                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
+                    result.push('-');
+                },
                 _ => (),
             }
-            flag = 5;
             result.push(ch);
+            flag = ChIs::Others;
         } else if keeped.contains(ch) {
-            if flag == 3 {
-                result.push('-');
+            match flag {
+                ChIs::NextOfSepMark => result.push('-'),
+                _ => (),
             }
-            flag = 4;
             result.push(ch);
+            flag = ChIs::NextOfKeepedMark;
         } else {
-            if flag != 0 {
-                flag = 3;
+            match flag {
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfSepMark,
             }
         }
     }

--- a/src/cobol_case.rs
+++ b/src/cobol_case.rs
@@ -20,11 +20,11 @@ pub fn cobol_case(input: &str) -> String {
     // .len returns byte count but ok in this case!
 
     enum ChIs {
-      FirstOfStr,
-      NextOfUpper,
-      NextOfContdUpper,
-      NextOfMark,
-      Others,
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfMark,
+        Others,
     }
     let mut flag = ChIs::FirstOfStr;
 
@@ -34,11 +34,11 @@ pub fn cobol_case(input: &str) -> String {
                 ChIs::FirstOfStr => {
                     result.push(ch);
                     flag = ChIs::NextOfUpper;
-                },
+                }
                 ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
                     result.push(ch);
                     flag = ChIs::NextOfContdUpper;
-                },
+                }
                 _ => {
                     result.push('-');
                     result.push(ch);
@@ -61,15 +61,15 @@ pub fn cobol_case(input: &str) -> String {
             flag = ChIs::Others;
         } else if ch.is_ascii_digit() {
             match flag {
-              ChIs::NextOfMark => result.push('-'),
-              _ => (),
+                ChIs::NextOfMark => result.push('-'),
+                _ => (),
             }
             result.push(ch);
             flag = ChIs::Others;
         } else {
             match flag {
-              ChIs::FirstOfStr => (),
-              _ => flag = ChIs::NextOfMark,
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfMark,
             }
         }
     }
@@ -96,12 +96,12 @@ pub fn cobol_case_with_sep(input: &str, seps: &str) -> String {
     // .len returns byte count but ok in this case!
 
     enum ChIs {
-      FirstOfStr,
-      NextOfUpper,
-      NextOfContdUpper,
-      NextOfSepMark,
-      NextOfKeepedMark,
-      Others,
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfSepMark,
+        NextOfKeepedMark,
+        Others,
     }
     let mut flag = ChIs::FirstOfStr;
 
@@ -116,11 +116,11 @@ pub fn cobol_case_with_sep(input: &str, seps: &str) -> String {
                 ChIs::FirstOfStr => {
                     result.push(ch);
                     flag = ChIs::NextOfUpper;
-                },
+                }
                 ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
                     result.push(ch);
                     flag = ChIs::NextOfContdUpper;
-                },
+                }
                 _ => {
                     result.push('-');
                     result.push(ch);
@@ -138,7 +138,7 @@ pub fn cobol_case_with_sep(input: &str, seps: &str) -> String {
                 },
                 ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
                     result.push('-');
-                },
+                }
                 _ => (),
             }
             result.push(ch.to_ascii_uppercase());
@@ -147,7 +147,7 @@ pub fn cobol_case_with_sep(input: &str, seps: &str) -> String {
             match flag {
                 ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
                     result.push('-');
-                },
+                }
                 _ => (),
             }
             result.push(ch);
@@ -185,12 +185,12 @@ pub fn cobol_case_with_keep(input: &str, keeped: &str) -> String {
     // .len returns byte count but ok in this case!
 
     enum ChIs {
-      FirstOfStr,
-      NextOfUpper,
-      NextOfContdUpper,
-      NextOfSepMark,
-      NextOfKeepedMark,
-      Others,
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfSepMark,
+        NextOfKeepedMark,
+        Others,
     }
     let mut flag = ChIs::FirstOfStr;
 
@@ -200,16 +200,16 @@ pub fn cobol_case_with_keep(input: &str, keeped: &str) -> String {
                 ChIs::FirstOfStr => {
                     result.push(ch);
                     flag = ChIs::NextOfUpper;
-                },
+                }
                 ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
                     result.push(ch);
                     flag = ChIs::NextOfContdUpper;
-                },
+                }
                 _ => {
                     result.push('-');
                     result.push(ch);
                     flag = ChIs::NextOfUpper;
-                },
+                }
             }
         } else if ch.is_ascii_lowercase() {
             match flag {
@@ -220,9 +220,9 @@ pub fn cobol_case_with_keep(input: &str, keeped: &str) -> String {
                     }
                     None => (), // impossible
                 },
-                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark  => {
+                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
                     result.push('-');
-                },
+                }
                 _ => (),
             }
             result.push(ch.to_ascii_uppercase());
@@ -231,7 +231,7 @@ pub fn cobol_case_with_keep(input: &str, keeped: &str) -> String {
             match flag {
                 ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
                     result.push('-');
-                },
+                }
                 _ => (),
             }
             result.push(ch);

--- a/src/kebab_case.rs
+++ b/src/kebab_case.rs
@@ -197,16 +197,20 @@ pub fn kebab_case_with_keep(input: &str, keeped: &str) -> String {
     for ch in input.chars() {
         if ch.is_ascii_uppercase() {
             match flag {
-                ChIs::FirstOfStr => flag = ChIs::NextOfUpper,
+                ChIs::FirstOfStr => {
+                    result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::NextOfUpper;
+                },
                 ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
+                    result.push(ch.to_ascii_lowercase());
                     flag = ChIs::NextOfContdUpper;
                 },
                 _ => {
-                    flag = ChIs::NextOfUpper;
                     result.push('-');
+                    result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::NextOfUpper;
                 }
             }
-            result.push(ch.to_ascii_lowercase());
         } else if ch.is_ascii_lowercase() {
             match flag {
                 ChIs::NextOfContdUpper => match result.pop() {

--- a/src/kebab_case.rs
+++ b/src/kebab_case.rs
@@ -20,11 +20,11 @@ pub fn kebab_case(input: &str) -> String {
     // .len returns byte count but ok in this case!
 
     enum ChIs {
-      FirstOfStr,
-      NextOfUpper,
-      NextOfContdUpper,
-      NextOfMark,
-      Others,
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfMark,
+        Others,
     }
     let mut flag = ChIs::FirstOfStr;
 
@@ -34,11 +34,11 @@ pub fn kebab_case(input: &str) -> String {
                 ChIs::FirstOfStr => {
                     result.push(ch.to_ascii_lowercase());
                     flag = ChIs::NextOfUpper;
-                },
+                }
                 ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
                     result.push(ch.to_ascii_lowercase());
                     flag = ChIs::NextOfContdUpper;
-                },
+                }
                 _ => {
                     result.push('-');
                     result.push(ch.to_ascii_lowercase());
@@ -96,12 +96,12 @@ pub fn kebab_case_with_sep(input: &str, seps: &str) -> String {
     // .len returns byte count but ok in this case!
 
     enum ChIs {
-      FirstOfStr,
-      NextOfUpper,
-      NextOfContdUpper,
-      NextOfSepMark,
-      NextOfKeepedMark,
-      Others,
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfSepMark,
+        NextOfKeepedMark,
+        Others,
     }
     let mut flag = ChIs::FirstOfStr;
 
@@ -116,11 +116,11 @@ pub fn kebab_case_with_sep(input: &str, seps: &str) -> String {
                 ChIs::FirstOfStr => {
                     result.push(ch.to_ascii_lowercase());
                     flag = ChIs::NextOfUpper;
-                },
+                }
                 ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
                     result.push(ch.to_ascii_lowercase());
                     flag = ChIs::NextOfContdUpper;
-                },
+                }
                 _ => {
                     result.push('-');
                     result.push(ch.to_ascii_lowercase());
@@ -138,7 +138,7 @@ pub fn kebab_case_with_sep(input: &str, seps: &str) -> String {
                 },
                 ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
                     result.push('-');
-                },
+                }
                 _ => (),
             }
             flag = ChIs::Others;
@@ -147,7 +147,7 @@ pub fn kebab_case_with_sep(input: &str, seps: &str) -> String {
             match flag {
                 ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
                     result.push('-');
-                },
+                }
                 _ => (),
             }
             flag = ChIs::Others;
@@ -185,12 +185,12 @@ pub fn kebab_case_with_keep(input: &str, keeped: &str) -> String {
     // .len returns byte count but ok in this case!
 
     enum ChIs {
-      FirstOfStr,
-      NextOfUpper,
-      NextOfContdUpper,
-      NextOfSepMark,
-      NextOfKeepedMark,
-      Others,
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfSepMark,
+        NextOfKeepedMark,
+        Others,
     }
     let mut flag = ChIs::FirstOfStr;
 
@@ -200,11 +200,11 @@ pub fn kebab_case_with_keep(input: &str, keeped: &str) -> String {
                 ChIs::FirstOfStr => {
                     result.push(ch.to_ascii_lowercase());
                     flag = ChIs::NextOfUpper;
-                },
+                }
                 ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
                     result.push(ch.to_ascii_lowercase());
                     flag = ChIs::NextOfContdUpper;
-                },
+                }
                 _ => {
                     result.push('-');
                     result.push(ch.to_ascii_lowercase());
@@ -222,7 +222,7 @@ pub fn kebab_case_with_keep(input: &str, keeped: &str) -> String {
                 },
                 ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
                     result.push('-');
-                },
+                }
                 _ => (),
             }
             result.push(ch);
@@ -231,7 +231,7 @@ pub fn kebab_case_with_keep(input: &str, keeped: &str) -> String {
             match flag {
                 ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
                     result.push('-');
-                },
+                }
                 _ => (),
             }
             result.push(ch);

--- a/src/macro_case.rs
+++ b/src/macro_case.rs
@@ -34,16 +34,16 @@ pub fn macro_case(input: &str) -> String {
                 ChIs::FirstOfStr => {
                     result.push(ch);
                     flag = ChIs::NextOfUpper;
-                },
+                }
                 ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
                     result.push(ch);
                     flag = ChIs::NextOfContdUpper;
-                },
+                }
                 _ => {
                     result.push('_');
                     result.push(ch);
                     flag = ChIs::NextOfUpper;
-                },
+                }
             }
         } else if ch.is_ascii_lowercase() {
             match flag {
@@ -116,11 +116,11 @@ pub fn macro_case_with_sep(input: &str, seps: &str) -> String {
                 ChIs::FirstOfStr => {
                     result.push(ch);
                     flag = ChIs::NextOfUpper;
-                },
+                }
                 ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
                     result.push(ch);
                     flag = ChIs::NextOfContdUpper;
-                },
+                }
                 _ => {
                     result.push('_');
                     result.push(ch);
@@ -138,7 +138,7 @@ pub fn macro_case_with_sep(input: &str, seps: &str) -> String {
                 },
                 ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
                     result.push('_');
-                },
+                }
                 _ => (),
             }
             result.push(ch.to_ascii_uppercase());
@@ -147,7 +147,7 @@ pub fn macro_case_with_sep(input: &str, seps: &str) -> String {
             match flag {
                 ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
                     result.push('_');
-                },
+                }
                 _ => (),
             }
             result.push(ch);
@@ -200,11 +200,11 @@ pub fn macro_case_with_keep(input: &str, keeped: &str) -> String {
                 ChIs::FirstOfStr => {
                     result.push(ch);
                     flag = ChIs::NextOfUpper;
-                },
+                }
                 ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
                     result.push(ch);
                     flag = ChIs::NextOfContdUpper;
-                },
+                }
                 _ => {
                     result.push('_');
                     result.push(ch);
@@ -222,7 +222,7 @@ pub fn macro_case_with_keep(input: &str, keeped: &str) -> String {
                 },
                 ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
                     result.push('_');
-                },
+                }
                 _ => (),
             }
             result.push(ch.to_ascii_uppercase());
@@ -231,7 +231,7 @@ pub fn macro_case_with_keep(input: &str, keeped: &str) -> String {
             match flag {
                 ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
                     result.push('_');
-                },
+                }
                 _ => (),
             }
             result.push(ch);

--- a/src/macro_case.rs
+++ b/src/macro_case.rs
@@ -19,47 +19,57 @@ pub fn macro_case(input: &str) -> String {
     let mut result = String::with_capacity(input.len() + input.len() / 2);
     // .len returns byte count but ok in this case!
 
-    let mut flag: u8 = 0;
-    // 0: first char
-    // 1: previous char is upper
-    // 2: one and two chars before are upper
-    // 3: previous char is mark
-    // 4: other
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfMark,
+        Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
 
     for ch in input.chars() {
         if ch.is_ascii_uppercase() {
             match flag {
-                0 => flag = 1,
-                1 | 2 => flag = 2,
+                ChIs::FirstOfStr => {
+                    result.push(ch);
+                    flag = ChIs::NextOfUpper;
+                },
+                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
+                    result.push(ch);
+                    flag = ChIs::NextOfContdUpper;
+                },
                 _ => {
-                    flag = 1;
                     result.push('_');
-                }
+                    result.push(ch);
+                    flag = ChIs::NextOfUpper;
+                },
             }
-            result.push(ch);
         } else if ch.is_ascii_lowercase() {
             match flag {
-                2 => match result.pop() {
+                ChIs::NextOfContdUpper => match result.pop() {
                     Some(prev) => {
                         result.push('_');
                         result.push(prev);
                     }
                     None => (), // impossible
                 },
-                3 => result.push('_'),
+                ChIs::NextOfMark => result.push('_'),
                 _ => (),
             }
-            flag = 4;
             result.push(ch.to_ascii_uppercase());
+            flag = ChIs::Others;
         } else if ch.is_ascii_digit() {
-            if flag == 3 {
-                result.push('_');
+            match flag {
+                ChIs::NextOfMark => result.push('_'),
+                _ => (),
             }
-            flag = 4;
-            result.push(ch)
+            result.push(ch);
+            flag = ChIs::Others;
         } else {
-            if flag != 0 {
-                flag = 3;
+            match flag {
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfMark,
             }
         }
     }
@@ -85,56 +95,70 @@ pub fn macro_case_with_sep(input: &str, seps: &str) -> String {
     let mut result = String::with_capacity(input.len() + input.len() / 2);
     // .len returns byte count but ok in this case!
 
-    let mut flag: u8 = 0;
-    // 0: first char
-    // 1: previous char is upper
-    // 2: one and two chars before are upper
-    // 3: previous char is mark (separator)
-    // 4: previous char is mark (keeped)
-    // 5: other
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfSepMark,
+        NextOfKeepedMark,
+        Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
 
     for ch in input.chars() {
         if seps.contains(ch) {
-            if flag != 0 {
-                flag = 3;
+            match flag {
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfSepMark,
             }
         } else if ch.is_ascii_uppercase() {
             match flag {
-                0 => flag = 1,
-                1 | 2 => flag = 2,
+                ChIs::FirstOfStr => {
+                    result.push(ch);
+                    flag = ChIs::NextOfUpper;
+                },
+                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
+                    result.push(ch);
+                    flag = ChIs::NextOfContdUpper;
+                },
                 _ => {
-                    flag = 1;
                     result.push('_');
+                    result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
             }
-            result.push(ch);
         } else if ch.is_ascii_lowercase() {
             match flag {
-                2 => match result.pop() {
+                ChIs::NextOfContdUpper => match result.pop() {
                     Some(prev) => {
                         result.push('_');
                         result.push(prev);
                     }
                     None => (), // impossible
                 },
-                3 | 4 => result.push('_'),
+                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
+                    result.push('_');
+                },
                 _ => (),
             }
-            flag = 5;
             result.push(ch.to_ascii_uppercase());
+            flag = ChIs::Others;
         } else if ch.is_ascii_digit() {
             match flag {
-                3 | 4 => result.push('_'),
+                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
+                    result.push('_');
+                },
                 _ => (),
             }
-            flag = 5;
             result.push(ch);
+            flag = ChIs::Others;
         } else {
-            if flag == 3 {
-                result.push('_');
+            match flag {
+                ChIs::NextOfSepMark => result.push('_'),
+                _ => (),
             }
-            flag = 4;
             result.push(ch);
+            flag = ChIs::NextOfKeepedMark;
         }
     }
 
@@ -160,55 +184,69 @@ pub fn macro_case_with_keep(input: &str, keeped: &str) -> String {
     let mut result = String::with_capacity(input.len() + input.len() / 2);
     // .len returns byte count but ok in this case!
 
-    let mut flag: u8 = 0;
-    // 0: first char
-    // 1: previous char is upper
-    // 2: one and two chars before are upper
-    // 3: previous char is mark (separator)
-    // 4: previous char is mark (keeped)
-    // 5: other
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfSepMark,
+        NextOfKeepedMark,
+        Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
 
     for ch in input.chars() {
         if ch.is_ascii_uppercase() {
             match flag {
-                0 => flag = 1,
-                1 | 2 => flag = 2,
+                ChIs::FirstOfStr => {
+                    result.push(ch);
+                    flag = ChIs::NextOfUpper;
+                },
+                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
+                    result.push(ch);
+                    flag = ChIs::NextOfContdUpper;
+                },
                 _ => {
-                    flag = 1;
                     result.push('_');
+                    result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
             }
-            result.push(ch);
         } else if ch.is_ascii_lowercase() {
             match flag {
-                2 => match result.pop() {
+                ChIs::NextOfContdUpper => match result.pop() {
                     Some(prev) => {
                         result.push('_');
                         result.push(prev);
                     }
                     None => (), // impossible
                 },
-                3 | 4 => result.push('_'),
+                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
+                    result.push('_');
+                },
                 _ => (),
             }
-            flag = 5;
             result.push(ch.to_ascii_uppercase());
+            flag = ChIs::Others;
         } else if ch.is_ascii_digit() {
             match flag {
-                3 | 4 => result.push('_'),
+                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
+                    result.push('_');
+                },
                 _ => (),
             }
-            flag = 5;
             result.push(ch);
+            flag = ChIs::Others;
         } else if keeped.contains(ch) {
-            if flag == 3 {
-                result.push('_');
+            match flag {
+                ChIs::NextOfSepMark => result.push('_'),
+                _ => (),
             }
-            flag = 4;
             result.push(ch);
+            flag = ChIs::NextOfKeepedMark;
         } else {
-            if flag != 0 {
-                flag = 3;
+            match flag {
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfSepMark,
             }
         }
     }

--- a/src/pascal_case.rs
+++ b/src/pascal_case.rs
@@ -19,57 +19,60 @@ pub fn pascal_case(input: &str) -> String {
     let mut result = String::with_capacity(input.len());
     // .len returns byte count but ok in this case!
 
-    let mut flag: u8 = 0;
-    // 0: first char
-    // 1: previous char is upper
-    // 2: previous char is mark
-    // 3: other
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfMark,
+        Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
 
     for ch in input.chars() {
         if ch.is_ascii_uppercase() {
             match flag {
-                1 => {
-                    flag = 1;
+                ChIs::NextOfUpper => {
                     result.push(ch.to_ascii_lowercase());
+                    //flag = ChIs::nextOfUpper;
                 }
                 _ => {
-                    flag = 1;
                     result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
             }
         } else if ch.is_ascii_lowercase() {
             match flag {
-                1 => match result.pop() {
+                ChIs::NextOfUpper => match result.pop() {
                     Some(prev) => {
-                        flag = 3;
                         result.push(prev.to_ascii_uppercase());
                         result.push(ch);
+                        flag = ChIs::Others;
                     }
                     None => (), // impossible
                 },
-                0 | 2 => {
-                    flag = 1;
+                ChIs::FirstOfStr | ChIs::NextOfMark => {
                     result.push(ch.to_ascii_uppercase());
+                    flag = ChIs::NextOfUpper;
                 }
                 _ => {
-                    flag = 3;
                     result.push(ch);
+                    flag = ChIs::Others;
                 }
             }
         } else if ch.is_ascii_digit() {
             match flag {
-                0 | 2 => {
-                    flag = 1;
+                ChIs::FirstOfStr | ChIs::NextOfMark => {
                     result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
                 _ => {
-                    flag = 3;
                     result.push(ch);
+                    flag = ChIs::Others;
                 }
             }
         } else {
-            if flag != 0 {
-                flag = 2;
+            match flag {
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfMark,
             }
         }
     }
@@ -95,61 +98,64 @@ pub fn pascal_case_with_sep(input: &str, seps: &str) -> String {
     let mut result = String::with_capacity(input.len());
     // .len returns byte count but ok in this case!
 
-    let mut flag: u8 = 0;
-    // 0: first char
-    // 1: previous char is upper
-    // 2: previous char is mark
-    // 3: other
+    enum ChIs {
+      FirstOfStr,
+      NextOfUpper,
+      NextOfMark,
+      Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
 
     for ch in input.chars() {
         if seps.contains(ch) {
-            if flag != 0 {
-                flag = 2;
+            match flag {
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfMark,
             }
         } else if ch.is_ascii_uppercase() {
             match flag {
-                1 => {
-                    flag = 1;
+                ChIs::NextOfUpper => {
                     result.push(ch.to_ascii_lowercase());
+                    //flag = ChIs::NextOfUpper;
                 }
                 _ => {
-                    flag = 1;
                     result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
             }
         } else if ch.is_ascii_lowercase() {
             match flag {
-                1 => match result.pop() {
+                ChIs::NextOfUpper => match result.pop() {
                     Some(prev) => {
-                        flag = 3;
                         result.push(prev.to_ascii_uppercase());
                         result.push(ch);
+                        flag = ChIs::Others;
                     }
                     None => (), // impossible
                 },
-                0 | 2 => {
-                    flag = 1;
+                ChIs::FirstOfStr | ChIs::NextOfMark => {
+                    flag = ChIs::NextOfUpper;
                     result.push(ch.to_ascii_uppercase());
                 }
                 _ => {
-                    flag = 3;
                     result.push(ch);
+                    flag = ChIs::Others;
                 }
             }
         } else if ch.is_ascii_digit() {
             match flag {
-                0 | 2 => {
-                    flag = 1;
+                ChIs::FirstOfStr | ChIs::NextOfMark => {
                     result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
                 _ => {
-                    flag = 3;
                     result.push(ch);
+                    flag = ChIs::Others;
                 }
             }
         } else {
-            flag = 2;
             result.push(ch);
+            flag = ChIs::NextOfMark;
         }
     }
 
@@ -175,60 +181,63 @@ pub fn pascal_case_with_keep(input: &str, keeped: &str) -> String {
     let mut result = String::with_capacity(input.len());
     // .len returns byte count but ok in this case!
 
-    let mut flag: u8 = 0;
-    // 0: first char
-    // 1: previous char is upper
-    // 2: previous char is mark
-    // 3: other
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfMark,
+        Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
 
     for ch in input.chars() {
         if ch.is_ascii_uppercase() {
             match flag {
-                1 => {
-                    flag = 1;
+                ChIs::NextOfUpper => {
                     result.push(ch.to_ascii_lowercase());
+                    //flag = ChIs::NextOfUpper;
                 }
                 _ => {
-                    flag = 1;
                     result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
             }
         } else if ch.is_ascii_lowercase() {
             match flag {
-                1 => match result.pop() {
+                ChIs::NextOfUpper => match result.pop() {
                     Some(prev) => {
-                        flag = 3;
                         result.push(prev.to_ascii_uppercase());
                         result.push(ch);
+                        flag = ChIs::Others;
                     }
                     None => (), // impossible
                 },
-                0 | 2 => {
-                    flag = 1;
+                ChIs::FirstOfStr | ChIs::NextOfMark => {
                     result.push(ch.to_ascii_uppercase());
+                    flag = ChIs::NextOfUpper;
                 }
                 _ => {
-                    flag = 3;
                     result.push(ch);
+                    flag = ChIs::Others;
                 }
             }
         } else if ch.is_ascii_digit() {
             match flag {
-                0 | 2 => {
-                    flag = 1;
+                ChIs::FirstOfStr | ChIs::NextOfMark => {
                     result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
                 _ => {
-                    flag = 3;
                     result.push(ch);
+                    flag = ChIs::Others;
                 }
             }
         } else if keeped.contains(ch) {
-            flag = 2;
             result.push(ch);
+            flag = ChIs::NextOfMark;
         } else {
-            if flag != 0 {
-                flag = 2;
+            match flag {
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfMark,
             }
         }
     }

--- a/src/pascal_case.rs
+++ b/src/pascal_case.rs
@@ -99,10 +99,10 @@ pub fn pascal_case_with_sep(input: &str, seps: &str) -> String {
     // .len returns byte count but ok in this case!
 
     enum ChIs {
-      FirstOfStr,
-      NextOfUpper,
-      NextOfMark,
-      Others,
+        FirstOfStr,
+        NextOfUpper,
+        NextOfMark,
+        Others,
     }
     let mut flag = ChIs::FirstOfStr;
 

--- a/src/snake_case.rs
+++ b/src/snake_case.rs
@@ -34,11 +34,11 @@ pub fn snake_case(input: &str) -> String {
                 ChIs::FirstOfStr => {
                     result.push(ch.to_ascii_lowercase());
                     flag = ChIs::NextOfUpper;
-                },
+                }
                 ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
                     result.push(ch.to_ascii_lowercase());
                     flag = ChIs::NextOfContdUpper;
-                },
+                }
                 _ => {
                     result.push('_');
                     result.push(ch.to_ascii_lowercase());
@@ -116,16 +116,16 @@ pub fn snake_case_with_sep(input: &str, seps: &str) -> String {
                 ChIs::FirstOfStr => {
                     result.push(ch.to_ascii_lowercase());
                     flag = ChIs::NextOfUpper;
-                },
+                }
                 ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
                     result.push(ch.to_ascii_lowercase());
                     flag = ChIs::NextOfContdUpper;
-                },
+                }
                 _ => {
                     result.push('_');
                     result.push(ch.to_ascii_lowercase());
                     flag = ChIs::NextOfUpper;
-                },
+                }
             }
         } else if ch.is_ascii_lowercase() {
             match flag {
@@ -138,7 +138,7 @@ pub fn snake_case_with_sep(input: &str, seps: &str) -> String {
                 },
                 ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
                     result.push('_');
-                },
+                }
                 _ => (),
             }
             result.push(ch);
@@ -147,7 +147,7 @@ pub fn snake_case_with_sep(input: &str, seps: &str) -> String {
             match flag {
                 ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
                     result.push('_');
-                },
+                }
                 _ => (),
             }
             result.push(ch);
@@ -200,11 +200,11 @@ pub fn snake_case_with_keep(input: &str, keeped: &str) -> String {
                 ChIs::FirstOfStr => {
                     result.push(ch.to_ascii_lowercase());
                     flag = ChIs::NextOfUpper;
-                },
+                }
                 ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
                     result.push(ch.to_ascii_lowercase());
                     flag = ChIs::NextOfContdUpper;
-                },
+                }
                 _ => {
                     result.push('_');
                     result.push(ch.to_ascii_lowercase());
@@ -222,7 +222,7 @@ pub fn snake_case_with_keep(input: &str, keeped: &str) -> String {
                 },
                 ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
                     result.push('_');
-                },
+                }
                 _ => (),
             }
             result.push(ch);
@@ -231,7 +231,7 @@ pub fn snake_case_with_keep(input: &str, keeped: &str) -> String {
             match flag {
                 ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
                     result.push('_');
-                },
+                }
                 _ => (),
             }
             result.push(ch);
@@ -245,8 +245,8 @@ pub fn snake_case_with_keep(input: &str, keeped: &str) -> String {
             flag = ChIs::NextOfKeepedMark;
         } else {
             match flag {
-               ChIs::FirstOfStr => (),
-               _ => flag = ChIs::NextOfSepMark,
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfSepMark,
             }
         }
     }

--- a/src/snake_case.rs
+++ b/src/snake_case.rs
@@ -150,15 +150,15 @@ pub fn snake_case_with_sep(input: &str, seps: &str) -> String {
                 },
                 _ => (),
             }
-            flag = ChIs::Others;
             result.push(ch);
+            flag = ChIs::Others;
         } else {
             match flag {
                 ChIs::NextOfSepMark => result.push('_'),
                 _ => (),
             }
-            flag = ChIs::NextOfKeepedMark;
             result.push(ch);
+            flag = ChIs::NextOfKeepedMark;
         }
     }
 

--- a/src/snake_case.rs
+++ b/src/snake_case.rs
@@ -19,47 +19,57 @@ pub fn snake_case(input: &str) -> String {
     let mut result = String::with_capacity(input.len() + input.len() / 2);
     // .len returns byte count but ok in this case!
 
-    let mut flag: u8 = 0;
-    // 0: first char
-    // 1: previous char is upper
-    // 2: one and two chars before are upper
-    // 3: previous char is mark
-    // 4: other
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfMark,
+        Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
 
     for ch in input.chars() {
         if ch.is_ascii_uppercase() {
             match flag {
-                0 => flag = 1,
-                1 | 2 => flag = 2,
+                ChIs::FirstOfStr => {
+                    result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::NextOfUpper;
+                },
+                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
+                    result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::NextOfContdUpper;
+                },
                 _ => {
-                    flag = 1;
                     result.push('_');
+                    result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::NextOfUpper;
                 }
             }
-            result.push(ch.to_ascii_lowercase());
         } else if ch.is_ascii_lowercase() {
             match flag {
-                2 => match result.pop() {
+                ChIs::NextOfContdUpper => match result.pop() {
                     Some(prev) => {
                         result.push('_');
                         result.push(prev);
                     }
                     None => (), // impossible
                 },
-                3 => result.push('_'),
+                ChIs::NextOfMark => result.push('_'),
                 _ => (),
             }
-            flag = 4;
             result.push(ch);
+            flag = ChIs::Others;
         } else if ch.is_ascii_digit() {
-            if flag == 3 {
-                result.push('_');
+            match flag {
+                ChIs::NextOfMark => result.push('_'),
+                _ => (),
             }
-            flag = 4;
             result.push(ch);
+            flag = ChIs::Others;
         } else {
-            if flag != 0 {
-                flag = 3;
+            match flag {
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfMark,
             }
         }
     }
@@ -85,55 +95,69 @@ pub fn snake_case_with_sep(input: &str, seps: &str) -> String {
     let mut result = String::with_capacity(input.len() + input.len() / 2);
     // .len returns byte count but ok in this case!
 
-    let mut flag: u8 = 0;
-    // 0: first char
-    // 1: previous char is upper
-    // 2: one and two chars before are upper
-    // 3: previous char is mark (separator)
-    // 4: previous char is mark (keeped)
-    // 5: other
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfSepMark,
+        NextOfKeepedMark,
+        Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
 
     for ch in input.chars() {
         if seps.contains(ch) {
-            if flag != 0 {
-                flag = 3;
+            match flag {
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfSepMark,
             }
         } else if ch.is_ascii_uppercase() {
             match flag {
-                0 => flag = 1,
-                1 | 2 => flag = 2,
+                ChIs::FirstOfStr => {
+                    result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::NextOfUpper;
+                },
+                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
+                    result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::NextOfContdUpper;
+                },
                 _ => {
-                    flag = 1;
                     result.push('_');
-                }
+                    result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::NextOfUpper;
+                },
             }
-            result.push(ch.to_ascii_lowercase());
         } else if ch.is_ascii_lowercase() {
             match flag {
-                2 => match result.pop() {
+                ChIs::NextOfContdUpper => match result.pop() {
                     Some(prev) => {
                         result.push('_');
                         result.push(prev);
                     }
                     None => (), // impossible
                 },
-                3 | 4 => result.push('_'),
+                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
+                    result.push('_');
+                },
                 _ => (),
             }
-            flag = 5;
             result.push(ch);
+            flag = ChIs::Others;
         } else if ch.is_ascii_digit() {
             match flag {
-                3 | 4 => result.push('_'),
+                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
+                    result.push('_');
+                },
                 _ => (),
             }
-            flag = 5;
+            flag = ChIs::Others;
             result.push(ch);
         } else {
-            if flag == 3 {
-                result.push('_');
+            match flag {
+                ChIs::NextOfSepMark => result.push('_'),
+                _ => (),
             }
-            flag = 4;
+            flag = ChIs::NextOfKeepedMark;
             result.push(ch);
         }
     }
@@ -160,55 +184,69 @@ pub fn snake_case_with_keep(input: &str, keeped: &str) -> String {
     let mut result = String::with_capacity(input.len() + input.len() / 2);
     // .len returns byte count but ok in this case!
 
-    let mut flag: u8 = 0;
-    // 0: first char
-    // 1: previous char is upper
-    // 2: one and two chars before are upper
-    // 3: previous char is mark (separator)
-    // 4: previous char is mark (keeped)
-    // 5: other
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfSepMark,
+        NextOfKeepedMark,
+        Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
 
     for ch in input.chars() {
         if ch.is_ascii_uppercase() {
             match flag {
-                0 => flag = 1,
-                1 | 2 => flag = 2,
+                ChIs::FirstOfStr => {
+                    result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::NextOfUpper;
+                },
+                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
+                    result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::NextOfContdUpper;
+                },
                 _ => {
-                    flag = 1;
                     result.push('_');
+                    result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::NextOfUpper;
                 }
             }
-            result.push(ch.to_ascii_lowercase());
         } else if ch.is_ascii_lowercase() {
             match flag {
-                2 => match result.pop() {
+                ChIs::NextOfContdUpper => match result.pop() {
                     Some(prev) => {
                         result.push('_');
                         result.push(prev);
                     }
                     None => (), // impossible
                 },
-                3 | 4 => result.push('_'),
+                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
+                    result.push('_');
+                },
                 _ => (),
             }
-            flag = 5;
             result.push(ch);
+            flag = ChIs::Others;
         } else if ch.is_ascii_digit() {
             match flag {
-                3 | 4 => result.push('_'),
+                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
+                    result.push('_');
+                },
                 _ => (),
             }
-            flag = 5;
             result.push(ch);
+            flag = ChIs::Others;
         } else if keeped.contains(ch) {
-            if flag == 3 {
-                result.push('_');
+            match flag {
+                ChIs::NextOfSepMark => result.push('_'),
+                _ => (),
             }
-            flag = 4;
             result.push(ch);
+            flag = ChIs::NextOfKeepedMark;
         } else {
-            if flag != 0 {
-                flag = 3;
+            match flag {
+               ChIs::FirstOfStr => (),
+               _ => flag = ChIs::NextOfSepMark,
             }
         }
     }

--- a/src/train_case.rs
+++ b/src/train_case.rs
@@ -34,11 +34,11 @@ pub fn train_case(input: &str) -> String {
                 ChIs::FirstOfStr => {
                     result.push(ch);
                     flag = ChIs::NextOfUpper;
-                },
+                }
                 ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
                     result.push(ch.to_ascii_lowercase());
                     flag = ChIs::NextOfContdUpper;
-                },
+                }
                 _ => {
                     result.push('-');
                     result.push(ch);
@@ -96,8 +96,8 @@ pub fn train_case(input: &str) -> String {
             }
         } else {
             match flag {
-              ChIs::FirstOfStr => (),
-              _ => flag = ChIs::NextOfMark,
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfMark,
             }
         }
     }
@@ -124,11 +124,11 @@ pub fn train_case_with_sep(input: &str, seps: &str) -> String {
     // .len returns byte count but ok in this case!
 
     enum ChIs {
-      FirstOfStr,
-      NextOfUpper,
-      NextOfContdUpper,
-      NextOfMark,
-      Others,
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfMark,
+        Others,
     }
     let mut flag = ChIs::FirstOfStr;
 
@@ -143,11 +143,11 @@ pub fn train_case_with_sep(input: &str, seps: &str) -> String {
                 ChIs::FirstOfStr => {
                     result.push(ch);
                     flag = ChIs::NextOfUpper;
-                },
+                }
                 ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
                     result.push(ch.to_ascii_lowercase());
                     flag = ChIs::NextOfContdUpper;
-                },
+                }
                 _ => {
                     result.push('-');
                     result.push(ch);
@@ -246,7 +246,7 @@ pub fn train_case_with_keep(input: &str, keeped: &str) -> String {
                 ChIs::FirstOfStr => {
                     result.push(ch);
                     flag = ChIs::NextOfUpper;
-                },
+                }
                 ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
                     result.push(ch.to_ascii_lowercase());
                     flag = ChIs::NextOfContdUpper;
@@ -311,8 +311,8 @@ pub fn train_case_with_keep(input: &str, keeped: &str) -> String {
             flag = ChIs::NextOfMark;
         } else {
             match flag {
-              ChIs::FirstOfStr => (),
-              _ => flag = ChIs::NextOfMark,
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfMark,
             }
         }
     }

--- a/src/train_case.rs
+++ b/src/train_case.rs
@@ -19,82 +19,85 @@ pub fn train_case(input: &str) -> String {
     let mut result = String::with_capacity(input.len() * 2);
     // .len returns byte count but ok in this case!
 
-    let mut flag: u8 = 0;
-    // 0: first char
-    // 1: previous char is upper
-    // 2: one and two chars before are upper
-    // 3: previous char is mark
-    // 4: other
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfMark,
+        Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
 
     for ch in input.chars() {
         if ch.is_ascii_uppercase() {
             match flag {
-                1 | 2 => {
-                    flag = 2;
-                    result.push(ch.to_ascii_lowercase());
-                }
-                0 => {
-                    flag = 1;
+                ChIs::FirstOfStr => {
                     result.push(ch);
-                }
+                    flag = ChIs::NextOfUpper;
+                },
+                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
+                    result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::NextOfContdUpper;
+                },
                 _ => {
-                    flag = 1;
                     result.push('-');
                     result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
             }
         } else if ch.is_ascii_lowercase() {
             match flag {
-                0 => {
-                    flag = 1;
+                ChIs::FirstOfStr => {
                     result.push(ch.to_ascii_uppercase());
+                    flag = ChIs::NextOfUpper;
                 }
-                1 => match result.pop() {
+                ChIs::NextOfUpper => match result.pop() {
                     Some(prev) => {
-                        flag = 4;
                         result.push(prev.to_ascii_uppercase());
                         result.push(ch);
+                        flag = ChIs::Others;
                     }
                     None => (), // impossible
                 },
-                2 => match result.pop() {
+                ChIs::NextOfContdUpper => match result.pop() {
                     Some(prev) => {
-                        flag = 4;
                         result.push('-');
                         result.push(prev.to_ascii_uppercase());
                         result.push(ch);
+                        flag = ChIs::Others;
                     }
                     None => (), // impossible
                 },
-                3 => {
-                    flag = 1;
+                ChIs::NextOfMark => {
                     result.push('-');
                     result.push(ch.to_ascii_uppercase());
+                    flag = ChIs::NextOfUpper;
                 }
                 _ => {
-                    flag = 4;
                     result.push(ch);
+                    flag = ChIs::Others;
                 }
             }
         } else if ch.is_ascii_digit() {
             match flag {
-                0 => {
-                    flag = 1;
+                ChIs::FirstOfStr => {
                     result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
-                3 => {
-                    flag = 1;
+                ChIs::NextOfMark => {
                     result.push('-');
                     result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
                 _ => {
-                    flag = 4;
                     result.push(ch);
+                    flag = ChIs::Others;
                 }
             }
         } else {
-            if flag != 0 {
-                flag = 3;
+            match flag {
+              ChIs::FirstOfStr => (),
+              _ => flag = ChIs::NextOfMark,
             }
         }
     }
@@ -120,86 +123,89 @@ pub fn train_case_with_sep(input: &str, seps: &str) -> String {
     let mut result = String::with_capacity(input.len() * 2);
     // .len returns byte count but ok in this case!
 
-    let mut flag: u8 = 0;
-    // 0: first char
-    // 1: previous char is upper
-    // 2: one and two chars before are upper
-    // 3: previous char is mark
-    // 4: other
+    enum ChIs {
+      FirstOfStr,
+      NextOfUpper,
+      NextOfContdUpper,
+      NextOfMark,
+      Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
 
     for ch in input.chars() {
         if seps.contains(ch) {
-            if flag != 0 {
-                flag = 3;
+            match flag {
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfMark,
             }
         } else if ch.is_ascii_uppercase() {
             match flag {
-                1 | 2 => {
-                    flag = 2;
-                    result.push(ch.to_ascii_lowercase());
-                }
-                0 => {
-                    flag = 1;
+                ChIs::FirstOfStr => {
                     result.push(ch);
-                }
+                    flag = ChIs::NextOfUpper;
+                },
+                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
+                    result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::NextOfContdUpper;
+                },
                 _ => {
-                    flag = 1;
                     result.push('-');
                     result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
             }
         } else if ch.is_ascii_lowercase() {
             match flag {
-                0 => {
-                    flag = 1;
+                ChIs::FirstOfStr => {
                     result.push(ch.to_ascii_uppercase());
+                    flag = ChIs::NextOfUpper;
                 }
-                1 => match result.pop() {
+                ChIs::NextOfUpper => match result.pop() {
                     Some(prev) => {
-                        flag = 4;
                         result.push(prev.to_ascii_uppercase());
                         result.push(ch);
+                        flag = ChIs::Others;
                     }
                     None => (), // impossible
                 },
-                2 => match result.pop() {
+                ChIs::NextOfContdUpper => match result.pop() {
                     Some(prev) => {
-                        flag = 4;
                         result.push('-');
                         result.push(prev.to_ascii_uppercase());
                         result.push(ch);
+                        flag = ChIs::Others;
                     }
                     None => (), // impossible
                 },
-                3 => {
-                    flag = 1;
+                ChIs::NextOfMark => {
                     result.push('-');
                     result.push(ch.to_ascii_uppercase());
+                    flag = ChIs::NextOfUpper;
                 }
                 _ => {
-                    flag = 4;
                     result.push(ch);
+                    flag = ChIs::Others;
                 }
             }
         } else if ch.is_ascii_digit() {
             match flag {
-                0 => {
-                    flag = 1;
+                ChIs::FirstOfStr => {
                     result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
-                3 => {
-                    flag = 1;
+                ChIs::NextOfMark => {
                     result.push('-');
                     result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
                 _ => {
-                    flag = 4;
                     result.push(ch);
+                    flag = ChIs::Others;
                 }
             }
         } else {
-            flag = 3;
             result.push(ch);
+            flag = ChIs::NextOfMark;
         }
     }
 
@@ -225,85 +231,88 @@ pub fn train_case_with_keep(input: &str, keeped: &str) -> String {
     let mut result = String::with_capacity(input.len() * 2);
     // .len returns byte count but ok in this case!
 
-    let mut flag: u8 = 0;
-    // 0: first char
-    // 1: previous char is upper
-    // 2: one and two chars before are upper
-    // 3: previous char is mark
-    // 4: other
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfMark,
+        Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
 
     for ch in input.chars() {
         if ch.is_ascii_uppercase() {
             match flag {
-                1 | 2 => {
-                    flag = 2;
-                    result.push(ch.to_ascii_lowercase());
-                }
-                0 => {
-                    flag = 1;
+                ChIs::FirstOfStr => {
                     result.push(ch);
+                    flag = ChIs::NextOfUpper;
+                },
+                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
+                    result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::NextOfContdUpper;
                 }
                 _ => {
-                    flag = 1;
                     result.push('-');
                     result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
             }
         } else if ch.is_ascii_lowercase() {
             match flag {
-                0 => {
-                    flag = 1;
+                ChIs::FirstOfStr => {
                     result.push(ch.to_ascii_uppercase());
+                    flag = ChIs::NextOfUpper;
                 }
-                1 => match result.pop() {
+                ChIs::NextOfUpper => match result.pop() {
                     Some(prev) => {
-                        flag = 4;
                         result.push(prev.to_ascii_uppercase());
                         result.push(ch);
+                        flag = ChIs::Others;
                     }
                     None => (), // impossible
                 },
-                2 => match result.pop() {
+                ChIs::NextOfContdUpper => match result.pop() {
                     Some(prev) => {
-                        flag = 4;
                         result.push('-');
                         result.push(prev.to_ascii_uppercase());
                         result.push(ch);
+                        flag = ChIs::Others;
                     }
                     None => (), // impossible
                 },
-                3 => {
-                    flag = 1;
+                ChIs::NextOfMark => {
                     result.push('-');
                     result.push(ch.to_ascii_uppercase());
+                    flag = ChIs::NextOfUpper;
                 }
                 _ => {
-                    flag = 4;
                     result.push(ch);
+                    flag = ChIs::Others;
                 }
             }
         } else if ch.is_ascii_digit() {
             match flag {
-                0 => {
-                    flag = 1;
+                ChIs::FirstOfStr => {
                     result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
-                3 => {
-                    flag = 1;
+                ChIs::NextOfMark => {
                     result.push('-');
                     result.push(ch);
+                    flag = ChIs::NextOfUpper;
                 }
                 _ => {
-                    flag = 4;
                     result.push(ch);
+                    flag = ChIs::Others;
                 }
             }
         } else if keeped.contains(ch) {
-            flag = 3;
             result.push(ch);
+            flag = ChIs::NextOfMark;
         } else {
-            if flag != 0 {
-                flag = 3;
+            match flag {
+              ChIs::FirstOfStr => (),
+              _ => flag = ChIs::NextOfMark,
             }
         }
     }

--- a/tests/camel_case_test.rs
+++ b/tests/camel_case_test.rs
@@ -1,4 +1,4 @@
-use stringcase::{camel_case, camel_case_with_sep, camel_case_with_keep};
+use stringcase::{camel_case, camel_case_with_keep, camel_case_with_sep};
 
 #[test]
 fn it_should_convert_to_camel_case() {

--- a/tests/cobol_case_test.rs
+++ b/tests/cobol_case_test.rs
@@ -1,4 +1,4 @@
-use stringcase::{cobol_case, cobol_case_with_sep, cobol_case_with_keep};
+use stringcase::{cobol_case, cobol_case_with_keep, cobol_case_with_sep};
 
 #[test]
 fn it_should_convert_to_cobol_case() {

--- a/tests/kebab_case_test.rs
+++ b/tests/kebab_case_test.rs
@@ -1,4 +1,4 @@
-use stringcase::{kebab_case, kebab_case_with_sep, kebab_case_with_keep};
+use stringcase::{kebab_case, kebab_case_with_keep, kebab_case_with_sep};
 
 #[test]
 fn it_should_convert_to_kebab_case() {

--- a/tests/macro_case_test.rs
+++ b/tests/macro_case_test.rs
@@ -1,4 +1,4 @@
-use stringcase::{macro_case, macro_case_with_sep, macro_case_with_keep};
+use stringcase::{macro_case, macro_case_with_keep, macro_case_with_sep};
 
 #[test]
 fn it_should_convert_to_macro_case() {

--- a/tests/pascal_case_test.rs
+++ b/tests/pascal_case_test.rs
@@ -1,4 +1,4 @@
-use stringcase::{pascal_case, pascal_case_with_sep, pascal_case_with_keep};
+use stringcase::{pascal_case, pascal_case_with_keep, pascal_case_with_sep};
 
 #[test]
 fn it_should_convert_to_pascal_case() {

--- a/tests/snake_case_test.rs
+++ b/tests/snake_case_test.rs
@@ -1,4 +1,4 @@
-use stringcase::{snake_case, snake_case_with_sep, snake_case_with_keep};
+use stringcase::{snake_case, snake_case_with_keep, snake_case_with_sep};
 
 #[test]
 fn it_should_convert_to_snake_case() {

--- a/tests/train_case_test.rs
+++ b/tests/train_case_test.rs
@@ -1,4 +1,4 @@
-use stringcase::{train_case, train_case_with_sep, train_case_with_keep};
+use stringcase::{train_case, train_case_with_keep, train_case_with_sep};
 
 #[test]
 fn it_should_convert_to_train_case() {


### PR DESCRIPTION
This PR changes each `flag`, that indicates the state of `ch`, in conversion functions from `u8` type to `enum`.