### PR TITLE
update!: changed to treat digits as keeped marks

### DIFF
--- a/src/camel_case.rs
+++ b/src/camel_case.rs
@@ -26,7 +26,6 @@ pub fn camel_case(input: &str) -> String {
         NextOfMark,
         Others,
     }
-
     let mut flag = ChIs::FirstOfStr;
 
     for ch in input.chars() {
@@ -66,10 +65,7 @@ pub fn camel_case(input: &str) -> String {
             }
         } else if ch.is_ascii_digit() {
             result.push(ch);
-            match flag {
-                ChIs::NextOfMark => flag = ChIs::NextOfUpper,
-                _ => flag = ChIs::Others,
-            }
+            flag = ChIs::NextOfMark;
         } else {
             match flag {
                 ChIs::FirstOfStr => (),
@@ -148,12 +144,6 @@ pub fn camel_case_with_sep(input: &str, seps: &str) -> String {
                     flag = ChIs::Others;
                 }
             }
-        } else if ch.is_ascii_digit() {
-            result.push(ch);
-            match flag {
-                ChIs::NextOfMark => flag = ChIs::NextOfUpper,
-                _ => flag = ChIs::Others,
-            }
         } else {
             result.push(ch);
             flag = ChIs::NextOfMark;
@@ -226,13 +216,7 @@ pub fn camel_case_with_keep(input: &str, keeped: &str) -> String {
                     flag = ChIs::Others;
                 }
             }
-        } else if ch.is_ascii_digit() {
-            result.push(ch);
-            match flag {
-                ChIs::NextOfMark => flag = ChIs::NextOfUpper,
-                _ => flag = ChIs::Others,
-            }
-        } else if keeped.contains(ch) {
+        } else if ch.is_ascii_digit() || keeped.contains(ch) {
             result.push(ch);
             flag = ChIs::NextOfMark;
         } else {
@@ -295,11 +279,20 @@ mod tests_of_camel_case {
     #[test]
     fn it_should_keep_digits() {
         let result = camel_case("abc123-456defG789HIJklMN12");
-        assert_eq!(result, "abc123456defG789HiJklMn12");
+        assert_eq!(result, "abc123456DefG789HiJklMn12");
     }
 
     #[test]
-    fn is_should_treat_marks_as_separators() {
+    fn it_should_convert_when_starting_with_digit() {
+        let result = camel_case("123abc456def");
+        assert_eq!(result, "123Abc456Def");
+
+        let result = camel_case("123ABC456DEF");
+        assert_eq!(result, "123Abc456Def");
+    }
+
+    #[test]
+    fn it_should_treat_marks_as_separators() {
         let result = camel_case(":.abc~!@def#$ghi%&jk(lm)no/?");
         assert_eq!(result, "abcDefGhiJkLmNo");
     }
@@ -375,14 +368,23 @@ mod tests_of_camel_case_with_sep {
     #[test]
     fn it_should_keep_digits() {
         let result = camel_case_with_sep("abc123-456defG789HIJklMN12", "_");
-        assert_eq!(result, "abc123-456defG789HiJklMn12");
+        assert_eq!(result, "abc123-456DefG789HiJklMn12");
 
         let result = camel_case_with_sep("abc123-456defG789HIJklMN12", "-");
-        assert_eq!(result, "abc123456defG789HiJklMn12");
+        assert_eq!(result, "abc123456DefG789HiJklMn12");
     }
 
     #[test]
-    fn is_should_treat_marks_as_separators() {
+    fn it_should_convert_when_starting_with_digit() {
+        let result = camel_case_with_sep("123abc456def", "-_");
+        assert_eq!(result, "123Abc456Def");
+
+        let result = camel_case_with_sep("123ABC456DEF", "-_");
+        assert_eq!(result, "123Abc456Def");
+    }
+
+    #[test]
+    fn it_should_treat_marks_as_separators() {
         let result = camel_case_with_sep(":.abc~!@def#$ghi%&jk(lm)no/?", ":@$&()/");
         assert_eq!(result, ".Abc~!Def#Ghi%JkLmNo?");
     }
@@ -458,14 +460,23 @@ mod tests_of_camel_case_with_keep {
     #[test]
     fn it_should_keep_digits() {
         let result = camel_case_with_keep("abc123-456defG789HIJklMN12", "_");
-        assert_eq!(result, "abc123456defG789HiJklMn12");
+        assert_eq!(result, "abc123456DefG789HiJklMn12");
 
         let result = camel_case_with_keep("abc123-456defG789HIJklMN12", "-");
-        assert_eq!(result, "abc123-456defG789HiJklMn12");
+        assert_eq!(result, "abc123-456DefG789HiJklMn12");
     }
 
     #[test]
-    fn is_should_treat_marks_as_separators() {
+    fn it_should_convert_when_starting_with_digit() {
+        let result = camel_case_with_keep("123abc456def", "_");
+        assert_eq!(result, "123Abc456Def");
+
+        let result = camel_case_with_keep("123ABC456DEF", "-");
+        assert_eq!(result, "123Abc456Def");
+    }
+
+    #[test]
+    fn it_should_treat_marks_as_separators() {
         let result = camel_case_with_keep(":.abc~!@def#$ghi%&jk(lm)no/?", ".~!#%?");
         assert_eq!(result, ".Abc~!Def#Ghi%JkLmNo?");
     }

--- a/src/pascal_case.rs
+++ b/src/pascal_case.rs
@@ -277,7 +277,7 @@ mod tests_of_pascal_case {
     }
 
     #[test]
-    fn is_should_treat_marks_as_separators() {
+    fn it_should_treat_marks_as_separators() {
         let result = pascal_case(":.abc~!@def#$ghi%&jk(lm)no/?");
         assert_eq!(result, "AbcDefGhiJkLmNo");
     }

--- a/src/pascal_case.rs
+++ b/src/pascal_case.rs
@@ -59,16 +59,8 @@ pub fn pascal_case(input: &str) -> String {
                 }
             }
         } else if ch.is_ascii_digit() {
-            match flag {
-                ChIs::FirstOfStr | ChIs::NextOfMark => {
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-                _ => {
-                    result.push(ch);
-                    flag = ChIs::Others;
-                }
-            }
+            result.push(ch);
+            flag = ChIs::NextOfMark;
         } else {
             match flag {
                 ChIs::FirstOfStr => (),
@@ -142,17 +134,6 @@ pub fn pascal_case_with_sep(input: &str, seps: &str) -> String {
                     flag = ChIs::Others;
                 }
             }
-        } else if ch.is_ascii_digit() {
-            match flag {
-                ChIs::FirstOfStr | ChIs::NextOfMark => {
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-                _ => {
-                    result.push(ch);
-                    flag = ChIs::Others;
-                }
-            }
         } else {
             result.push(ch);
             flag = ChIs::NextOfMark;
@@ -220,18 +201,7 @@ pub fn pascal_case_with_keep(input: &str, keeped: &str) -> String {
                     flag = ChIs::Others;
                 }
             }
-        } else if ch.is_ascii_digit() {
-            match flag {
-                ChIs::FirstOfStr | ChIs::NextOfMark => {
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-                _ => {
-                    result.push(ch);
-                    flag = ChIs::Others;
-                }
-            }
-        } else if keeped.contains(ch) {
+        } else if ch.is_ascii_digit() || keeped.contains(ch) {
             result.push(ch);
             flag = ChIs::NextOfMark;
         } else {
@@ -294,7 +264,16 @@ mod tests_of_pascal_case {
     #[test]
     fn it_should_keep_digits() {
         let result = pascal_case("abc123-456defG789HIJklMN12");
-        assert_eq!(result, "Abc123456defG789HiJklMn12");
+        assert_eq!(result, "Abc123456DefG789HiJklMn12");
+    }
+
+    #[test]
+    fn it_should_convert_when_starting_with_digit() {
+        let result = pascal_case("123abc456def");
+        assert_eq!(result, "123Abc456Def");
+
+        let result = pascal_case("123ABC456DEF");
+        assert_eq!(result, "123Abc456Def");
     }
 
     #[test]
@@ -374,10 +353,19 @@ mod tests_of_pascal_case_with_sep {
     #[test]
     fn it_should_keep_digits() {
         let result = pascal_case_with_sep("abc123-456defG789HIJklMN12", "-");
-        assert_eq!(result, "Abc123456defG789HiJklMn12");
+        assert_eq!(result, "Abc123456DefG789HiJklMn12");
 
         let result = pascal_case_with_sep("abc123-456defG789HIJklMN12", "_");
-        assert_eq!(result, "Abc123-456defG789HiJklMn12");
+        assert_eq!(result, "Abc123-456DefG789HiJklMn12");
+    }
+
+    #[test]
+    fn it_should_convert_when_starting_with_digit() {
+        let result = pascal_case_with_sep("123abc456def", "_");
+        assert_eq!(result, "123Abc456Def");
+
+        let result = pascal_case_with_sep("123ABC456DEF", "_");
+        assert_eq!(result, "123Abc456Def");
     }
 
     #[test]
@@ -457,10 +445,19 @@ mod tests_of_pascal_case_with_keep {
     #[test]
     fn it_should_keep_digits() {
         let result = pascal_case_with_keep("abc123-456defG789HIJklMN12", "_");
-        assert_eq!(result, "Abc123456defG789HiJklMn12");
+        assert_eq!(result, "Abc123456DefG789HiJklMn12");
 
         let result = pascal_case_with_keep("abc123-456defG789HIJklMN12", "-");
-        assert_eq!(result, "Abc123-456defG789HiJklMn12");
+        assert_eq!(result, "Abc123-456DefG789HiJklMn12");
+    }
+
+    #[test]
+    fn it_should_convert_when_starting_with_digit() {
+        let result = pascal_case_with_keep("123abc456def", "_");
+        assert_eq!(result, "123Abc456Def");
+
+        let result = pascal_case_with_keep("123ABC456DEF", "_");
+        assert_eq!(result, "123Abc456Def");
     }
 
     #[test]

--- a/src/snake_case.rs
+++ b/src/snake_case.rs
@@ -23,7 +23,8 @@ pub fn snake_case(input: &str) -> String {
         FirstOfStr,
         NextOfUpper,
         NextOfContdUpper,
-        NextOfMark,
+        NextOfSepMark,
+        NextOfKeepedMark,
         Others,
     }
     let mut flag = ChIs::FirstOfStr;
@@ -54,22 +55,22 @@ pub fn snake_case(input: &str) -> String {
                     }
                     None => (), // impossible
                 },
-                ChIs::NextOfMark => result.push('_'),
+                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => result.push('_'),
                 _ => (),
             }
             result.push(ch);
             flag = ChIs::Others;
         } else if ch.is_ascii_digit() {
             match flag {
-                ChIs::NextOfMark => result.push('_'),
+                ChIs::NextOfSepMark => result.push('_'),
                 _ => (),
             }
             result.push(ch);
-            flag = ChIs::Others;
+            flag = ChIs::NextOfKeepedMark;
         } else {
             match flag {
                 ChIs::FirstOfStr => (),
-                _ => flag = ChIs::NextOfMark,
+                _ => flag = ChIs::NextOfSepMark,
             }
         }
     }
@@ -136,15 +137,6 @@ pub fn snake_case_with_sep(input: &str, seps: &str) -> String {
                     }
                     None => (), // impossible
                 },
-                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
-                    result.push('_');
-                }
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::Others;
-        } else if ch.is_ascii_digit() {
-            match flag {
                 ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
                     result.push('_');
                 }
@@ -227,16 +219,7 @@ pub fn snake_case_with_keep(input: &str, keeped: &str) -> String {
             }
             result.push(ch);
             flag = ChIs::Others;
-        } else if ch.is_ascii_digit() {
-            match flag {
-                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
-                    result.push('_');
-                }
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::Others;
-        } else if keeped.contains(ch) {
+        } else if ch.is_ascii_digit() || keeped.contains(ch) {
             match flag {
                 ChIs::NextOfSepMark => result.push('_'),
                 _ => (),
@@ -303,7 +286,16 @@ mod tests_of_snake_case {
     #[test]
     fn it_should_keep_digits() {
         let result = snake_case("abc123-456defG789HIJklMN12");
-        assert_eq!(result, "abc123_456def_g789_hi_jkl_mn12");
+        assert_eq!(result, "abc123_456_def_g789_hi_jkl_mn12");
+    }
+
+    #[test]
+    fn it_should_convert_when_starting_with_digit() {
+        let result = snake_case("123abc456def");
+        assert_eq!(result, "123_abc456_def");
+
+        let result = snake_case("123ABC456DEF");
+        assert_eq!(result, "123_abc456_def");
     }
 
     #[test]
@@ -374,10 +366,19 @@ mod tests_of_snake_case_with_sep {
     #[test]
     fn it_should_keep_digits() {
         let result = snake_case_with_sep("abc123-456defG789HIJklMN12", "-");
-        assert_eq!(result, "abc123_456def_g789_hi_jkl_mn12");
+        assert_eq!(result, "abc123_456_def_g789_hi_jkl_mn12");
 
         let result = snake_case_with_sep("abc123-456defG789HIJklMN12", "_");
-        assert_eq!(result, "abc123-_456def_g789_hi_jkl_mn12");
+        assert_eq!(result, "abc123-456_def_g789_hi_jkl_mn12");
+    }
+
+    #[test]
+    fn it_should_convert_when_starting_with_digit() {
+        let result = snake_case_with_sep("123abc456def", "-");
+        assert_eq!(result, "123_abc456_def");
+
+        let result = snake_case_with_sep("123ABC456DEF", "_");
+        assert_eq!(result, "123_abc456_def");
     }
 
     #[test]
@@ -448,10 +449,19 @@ mod tests_of_snake_case_with_keep {
     #[test]
     fn it_should_keep_digits() {
         let result = snake_case_with_keep("abc123-456defG789HIJklMN12", "_");
-        assert_eq!(result, "abc123_456def_g789_hi_jkl_mn12");
+        assert_eq!(result, "abc123_456_def_g789_hi_jkl_mn12");
 
         let result = snake_case_with_keep("abc123-456defG789HIJklMN12", "-");
-        assert_eq!(result, "abc123-_456def_g789_hi_jkl_mn12");
+        assert_eq!(result, "abc123-456_def_g789_hi_jkl_mn12");
+    }
+
+    #[test]
+    fn it_should_convert_when_starting_with_digit() {
+        let result = snake_case_with_keep("123abc456def", "-");
+        assert_eq!(result, "123_abc456_def");
+
+        let result = snake_case_with_keep("123ABC456DEF", "_");
+        assert_eq!(result, "123_abc456_def");
     }
 
     #[test]

--- a/src/train_case.rs
+++ b/src/train_case.rs
@@ -79,21 +79,8 @@ pub fn train_case(input: &str) -> String {
                 }
             }
         } else if ch.is_ascii_digit() {
-            match flag {
-                ChIs::FirstOfStr => {
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-                ChIs::NextOfMark => {
-                    result.push('-');
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-                _ => {
-                    result.push(ch);
-                    flag = ChIs::Others;
-                }
-            }
+            result.push(ch);
+            flag = ChIs::NextOfMark;
         } else {
             match flag {
                 ChIs::FirstOfStr => (),
@@ -180,22 +167,6 @@ pub fn train_case_with_sep(input: &str, seps: &str) -> String {
                 ChIs::NextOfMark => {
                     result.push('-');
                     result.push(ch.to_ascii_uppercase());
-                    flag = ChIs::NextOfUpper;
-                }
-                _ => {
-                    result.push(ch);
-                    flag = ChIs::Others;
-                }
-            }
-        } else if ch.is_ascii_digit() {
-            match flag {
-                ChIs::FirstOfStr => {
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-                ChIs::NextOfMark => {
-                    result.push('-');
-                    result.push(ch);
                     flag = ChIs::NextOfUpper;
                 }
                 _ => {
@@ -290,23 +261,7 @@ pub fn train_case_with_keep(input: &str, keeped: &str) -> String {
                     flag = ChIs::Others;
                 }
             }
-        } else if ch.is_ascii_digit() {
-            match flag {
-                ChIs::FirstOfStr => {
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-                ChIs::NextOfMark => {
-                    result.push('-');
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-                _ => {
-                    result.push(ch);
-                    flag = ChIs::Others;
-                }
-            }
-        } else if keeped.contains(ch) {
+        } else if ch.is_ascii_digit() || keeped.contains(ch) {
             result.push(ch);
             flag = ChIs::NextOfMark;
         } else {
@@ -369,7 +324,16 @@ mod tests_of_train_case {
     #[test]
     fn it_should_keep_digits() {
         let result = train_case("abc123-456defG789HIJklMN12");
-        assert_eq!(result, "Abc123-456def-G789-Hi-Jkl-Mn12");
+        assert_eq!(result, "Abc123456-Def-G789-Hi-Jkl-Mn12");
+    }
+
+    #[test]
+    fn it_should_convert_when_starting_with_digit() {
+        let result = train_case("123abc456def");
+        assert_eq!(result, "123-Abc456-Def");
+
+        let result = train_case("123ABC456DEF");
+        assert_eq!(result, "123-Abc456-Def");
     }
 
     #[test]
@@ -449,10 +413,19 @@ mod tests_of_train_case_with_sep {
     #[test]
     fn it_should_keep_digits() {
         let result = train_case_with_sep("abc123-456defG789HIJklMN12", "-");
-        assert_eq!(result, "Abc123-456def-G789-Hi-Jkl-Mn12");
+        assert_eq!(result, "Abc123456-Def-G789-Hi-Jkl-Mn12");
 
         let result = train_case_with_sep("abc123-456defG789HIJklMN12", "_");
-        assert_eq!(result, "Abc123--456def-G789-Hi-Jkl-Mn12");
+        assert_eq!(result, "Abc123-456-Def-G789-Hi-Jkl-Mn12");
+    }
+
+    #[test]
+    fn it_should_convert_when_starting_with_digit() {
+        let result = train_case_with_sep("123abc456def", "-");
+        assert_eq!(result, "123-Abc456-Def");
+
+        let result = train_case_with_keep("123ABC456DEF", "_");
+        assert_eq!(result, "123-Abc456-Def");
     }
 
     #[test]
@@ -532,10 +505,19 @@ mod tests_of_train_case_with_keep {
     #[test]
     fn it_should_keep_digits() {
         let result = train_case_with_keep("abc123-456defG789HIJklMN12", "_");
-        assert_eq!(result, "Abc123-456def-G789-Hi-Jkl-Mn12");
+        assert_eq!(result, "Abc123456-Def-G789-Hi-Jkl-Mn12");
 
         let result = train_case_with_keep("abc123-456defG789HIJklMN12", "-");
-        assert_eq!(result, "Abc123--456def-G789-Hi-Jkl-Mn12");
+        assert_eq!(result, "Abc123-456-Def-G789-Hi-Jkl-Mn12");
+    }
+
+    #[test]
+    fn it_should_convert_when_starting_with_digit() {
+        let result = train_case_with_keep("123abc456def", "-");
+        assert_eq!(result, "123-Abc456-Def");
+
+        let result = train_case_with_keep("123ABC456DEF", "_");
+        assert_eq!(result, "123-Abc456-Def");
     }
 
     #[test]


### PR DESCRIPTION
This PR changes the conversion methods for digits.

Currently, digits are treated as lower case alphabets, but after this change, digits are treated as keeped marks.

For example, currently,
```rust
    snake_case("123abc456def"); // ==> "123abc456def"
    snake_case("123ABC456DEF"); // ==> "123_abc456_def"
```

And after this change,
```rust
    snake_case("123abc456def"); // ==> "123_abc456_def"
    snake_case("123ABC456DEF"); // ==> "123_abc456_def"
```