### PR TITLE
new: added functions to convert with a number sequence as a word

### DIFF
--- a/benches/benchmark.md
+++ b/benches/benchmark.md
@@ -1,4 +1,155 @@
+## 0.3.0
+
+> - Date: 2024/08/12
+> - rustc 1.80.1 (3f5fd8dd4 2024-08-06)
+
+```
+% ./build.sh bench
+
+running 320 tests
+iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii 87/320
+iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii 174/320
+iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii 261/320
+iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii
+test result: ok. 0 passed; 0 failed; 320 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 3 tests
+test bench_camel_case           ... bench:         117.95 ns/iter (+/- 5.98)
+test bench_camel_case_with_keep ... bench:         130.06 ns/iter (+/- 1.95)
+test bench_camel_case_with_sep  ... bench:         219.25 ns/iter (+/- 3.74)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured; 0 filtered out; finished in 0.61s
+
+
+running 4 tests
+test bench_cobol_case                   ... bench:         128.08 ns/iter (+/- 5.10)
+test bench_cobol_case_with_keep         ... bench:         145.26 ns/iter (+/- 3.27)
+test bench_cobol_case_with_nums_as_word ... bench:         125.37 ns/iter (+/- 3.79)
+test bench_cobol_case_with_sep          ... bench:         224.37 ns/iter (+/- 5.25)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 11.18s
+
+
+running 4 tests
+test bench_kebab_case                   ... bench:         114.68 ns/iter (+/- 5.19)
+test bench_kebab_case_with_keep         ... bench:         141.48 ns/iter (+/- 3.79)
+test bench_kebab_case_with_nums_as_word ... bench:         127.85 ns/iter (+/- 6.08)
+test bench_kebab_case_with_sep          ... bench:         209.53 ns/iter (+/- 10.48)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 1.85s
+
+
+running 4 tests
+test bench_macro_case                   ... bench:         128.51 ns/iter (+/- 5.29)
+test bench_macro_case_with_keep         ... bench:         144.81 ns/iter (+/- 5.90)
+test bench_macro_case_with_nums_as_word ... bench:         126.36 ns/iter (+/- 4.99)
+test bench_macro_case_with_sep          ... bench:         222.56 ns/iter (+/- 6.66)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 3.71s
+
+
+running 3 tests
+test bench_pascal_case           ... bench:         127.49 ns/iter (+/- 6.61)
+test bench_pascal_case_with_keep ... bench:         140.21 ns/iter (+/- 5.25)
+test bench_pascal_case_with_sep  ... bench:         237.46 ns/iter (+/- 6.03)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured; 0 filtered out; finished in 4.37s
+
+
+running 4 tests
+test bench_snake_case                   ... bench:         115.38 ns/iter (+/- 4.57)
+test bench_snake_case_with_keep         ... bench:         142.41 ns/iter (+/- 5.35)
+test bench_snake_case_with_nums_as_word ... bench:         126.88 ns/iter (+/- 4.01)
+test bench_snake_case_with_sep          ... bench:         211.74 ns/iter (+/- 8.32)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 5.14s
+
+
+running 4 tests
+test bench_train_case                   ... bench:         118.75 ns/iter (+/- 2.79)
+test bench_train_case_with_keep         ... bench:         136.30 ns/iter (+/- 8.72)
+test bench_train_case_with_nums_as_word ... bench:         118.41 ns/iter (+/- 2.57)
+test bench_train_case_with_sep          ... bench:         182.70 ns/iter (+/- 5.04)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 11.13s
+```
+
 ## 0.2.1
+
+> - Date: 2024/08/12
+> - rustc 1.80.1 (3f5fd8dd4 2024-08-06)
+
+```
+% ./build.sh bench
+
+running 248 tests
+iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii 87/248
+iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii 174/248
+iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii
+test result: ok. 0 passed; 0 failed; 248 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 3 tests
+test bench_camel_case           ... bench:         119.61 ns/iter (+/- 5.54)
+test bench_camel_case_with_keep ... bench:         133.05 ns/iter (+/- 5.09)
+test bench_camel_case_with_sep  ... bench:         220.75 ns/iter (+/- 5.18)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured; 0 filtered out; finished in 1.96s
+
+
+running 3 tests
+test bench_cobol_case           ... bench:         126.28 ns/iter (+/- 3.90)
+test bench_cobol_case_with_keep ... bench:         144.03 ns/iter (+/- 4.27)
+test bench_cobol_case_with_sep  ... bench:         220.31 ns/iter (+/- 5.63)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured; 0 filtered out; finished in 3.77s
+
+
+running 3 tests
+test bench_kebab_case           ... bench:         125.43 ns/iter (+/- 6.52)
+test bench_kebab_case_with_keep ... bench:         140.52 ns/iter (+/- 6.26)
+test bench_kebab_case_with_sep  ... bench:         213.29 ns/iter (+/- 8.70)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured; 0 filtered out; finished in 0.68s
+
+
+running 3 tests
+test bench_macro_case           ... bench:         124.57 ns/iter (+/- 4.52)
+test bench_macro_case_with_keep ... bench:         145.26 ns/iter (+/- 4.05)
+test bench_macro_case_with_sep  ... bench:         226.62 ns/iter (+/- 5.38)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured; 0 filtered out; finished in 4.33s
+
+
+running 3 tests
+test bench_pascal_case           ... bench:         124.71 ns/iter (+/- 4.41)
+test bench_pascal_case_with_keep ... bench:         137.41 ns/iter (+/- 3.87)
+test bench_pascal_case_with_sep  ... bench:         190.97 ns/iter (+/- 7.21)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured; 0 filtered out; finished in 6.78s
+
+
+running 3 tests
+test bench_snake_case           ... bench:         156.07 ns/iter (+/- 4.29)
+test bench_snake_case_with_keep ... bench:         167.70 ns/iter (+/- 4.13)
+test bench_snake_case_with_sep  ... bench:         242.15 ns/iter (+/- 5.27)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured; 0 filtered out; finished in 1.13s
+
+
+running 3 tests
+test bench_train_case           ... bench:         121.08 ns/iter (+/- 1.64)
+test bench_train_case_with_keep ... bench:         134.10 ns/iter (+/- 3.67)
+test bench_train_case_with_sep  ... bench:         212.42 ns/iter (+/- 5.32)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured; 0 filtered out; finished in 5.62s
+```
+
+## 0.2.1 
+
+> - Date: 2024/02/26
+> - Rust: 1.76.0 (c84b36747 2024-01-18)
 
 ```
 % ./build.sh bench

--- a/benches/cobol_case_bench.rs
+++ b/benches/cobol_case_bench.rs
@@ -2,7 +2,9 @@
 
 extern crate test;
 
-use stringcase::{cobol_case, cobol_case_with_keep, cobol_case_with_sep};
+use stringcase::{
+    cobol_case, cobol_case_with_keep, cobol_case_with_nums_as_word, cobol_case_with_sep,
+};
 use test::Bencher;
 
 #[bench]
@@ -18,4 +20,9 @@ fn bench_cobol_case_with_sep(b: &mut Bencher) {
 #[bench]
 fn bench_cobol_case_with_keep(b: &mut Bencher) {
     b.iter(|| cobol_case_with_keep("foo_bar100%BAZQux", "%"));
+}
+
+#[bench]
+fn bench_cobol_case_with_nums_as_word(b: &mut Bencher) {
+    b.iter(|| cobol_case_with_nums_as_word("foo_bar100%BAZQux"));
 }

--- a/benches/kebab_case_bench.rs
+++ b/benches/kebab_case_bench.rs
@@ -2,7 +2,9 @@
 
 extern crate test;
 
-use stringcase::{kebab_case, kebab_case_with_keep, kebab_case_with_sep};
+use stringcase::{
+    kebab_case, kebab_case_with_keep, kebab_case_with_nums_as_word, kebab_case_with_sep,
+};
 use test::Bencher;
 
 #[bench]
@@ -18,4 +20,9 @@ fn bench_kebab_case_with_sep(b: &mut Bencher) {
 #[bench]
 fn bench_kebab_case_with_keep(b: &mut Bencher) {
     b.iter(|| kebab_case_with_keep("foo_bar100%BAZQux", "%"));
+}
+
+#[bench]
+fn bench_kebab_case_with_nums_as_word(b: &mut Bencher) {
+    b.iter(|| kebab_case_with_nums_as_word("foo_bar100%BAZQux"));
 }

--- a/benches/macro_case_bench.rs
+++ b/benches/macro_case_bench.rs
@@ -2,7 +2,9 @@
 
 extern crate test;
 
-use stringcase::{macro_case, macro_case_with_keep, macro_case_with_sep};
+use stringcase::{
+    macro_case, macro_case_with_keep, macro_case_with_nums_as_word, macro_case_with_sep,
+};
 use test::Bencher;
 
 #[bench]
@@ -18,4 +20,9 @@ fn bench_macro_case_with_sep(b: &mut Bencher) {
 #[bench]
 fn bench_macro_case_with_keep(b: &mut Bencher) {
     b.iter(|| macro_case_with_keep("foo_bar100%BAZQux", "%"));
+}
+
+#[bench]
+fn bench_macro_case_with_nums_as_word(b: &mut Bencher) {
+    b.iter(|| macro_case_with_nums_as_word("foo_bar100%BAZQux"));
 }

--- a/benches/snake_case_test.rs
+++ b/benches/snake_case_test.rs
@@ -2,7 +2,9 @@
 
 extern crate test;
 
-use stringcase::{snake_case, snake_case_with_keep, snake_case_with_sep};
+use stringcase::{
+    snake_case, snake_case_with_keep, snake_case_with_nums_as_word, snake_case_with_sep,
+};
 use test::Bencher;
 
 #[bench]
@@ -18,4 +20,9 @@ fn bench_snake_case_with_sep(b: &mut Bencher) {
 #[bench]
 fn bench_snake_case_with_keep(b: &mut Bencher) {
     b.iter(|| snake_case_with_keep("foo_bar100%BAZQux", "%"));
+}
+
+#[bench]
+fn bench_snake_case_with_nums_as_word(b: &mut Bencher) {
+    b.iter(|| snake_case_with_nums_as_word("foo_bar100%BAZQux"));
 }

--- a/benches/train_case_test.rs
+++ b/benches/train_case_test.rs
@@ -2,7 +2,9 @@
 
 extern crate test;
 
-use stringcase::{train_case, train_case_with_keep, train_case_with_sep};
+use stringcase::{
+    train_case, train_case_with_keep, train_case_with_nums_as_word, train_case_with_sep,
+};
 use test::Bencher;
 
 #[bench]
@@ -18,4 +20,9 @@ fn bench_train_case_with_sep(b: &mut Bencher) {
 #[bench]
 fn bench_train_case_with_keep(b: &mut Bencher) {
     b.iter(|| train_case_with_keep("foo_bar100%BAZQux", "%"));
+}
+
+#[bench]
+fn bench_train_case_with_nums_as_word(b: &mut Bencher) {
+    b.iter(|| train_case_with_nums_as_word("foo_bar100%BAZQux"));
 }

--- a/src/camel_case.rs
+++ b/src/camel_case.rs
@@ -302,6 +302,60 @@ mod tests_of_camel_case {
         let result = camel_case("");
         assert_eq!(result, "");
     }
+
+    #[test]
+    fn it_should_treat_number_sequence_by_default() {
+        let result = camel_case("abc123Def456#Ghi789");
+        assert_eq!(result, "abc123Def456Ghi789");
+
+        let result = camel_case("ABC123-DEF456#GHI789");
+        assert_eq!(result, "abc123Def456Ghi789");
+
+        let result = camel_case("abc123-def456#ghi789");
+        assert_eq!(result, "abc123Def456Ghi789");
+
+        let result = camel_case("ABC123_DEF456#GHI789");
+        assert_eq!(result, "abc123Def456Ghi789");
+
+        let result = camel_case("Abc123Def456#Ghi789");
+        assert_eq!(result, "abc123Def456Ghi789");
+
+        let result = camel_case("abc123_def456#ghi789");
+        assert_eq!(result, "abc123Def456Ghi789");
+
+        let result = camel_case("Abc123-Def456#-Ghi789");
+        assert_eq!(result, "abc123Def456Ghi789");
+
+        let result = camel_case("000-abc123_def456#ghi789");
+        assert_eq!(result, "000Abc123Def456Ghi789");
+    }
+
+    #[test]
+    fn it_should_treat_number_sequence_as_word() {
+        let result = camel_case("abc123Def456#Ghi789");
+        assert_eq!(result, "abc123Def456Ghi789");
+
+        let result = camel_case("ABC-123-DEF-456#GHI-789");
+        assert_eq!(result, "abc123Def456Ghi789");
+
+        let result = camel_case("abc-123-def-456#ghi-789");
+        assert_eq!(result, "abc123Def456Ghi789");
+
+        let result = camel_case("ABC_123_DEF_456#GHI_789");
+        assert_eq!(result, "abc123Def456Ghi789");
+
+        let result = camel_case("Abc123Def456#Ghi789");
+        assert_eq!(result, "abc123Def456Ghi789");
+
+        let result = camel_case("abc_123_def_456#ghi_789");
+        assert_eq!(result, "abc123Def456Ghi789");
+
+        let result = camel_case("Abc-123-Def-456#Ghi-789");
+        assert_eq!(result, "abc123Def456Ghi789");
+
+        let result = camel_case("000_abc_123_def_456#ghi_789");
+        assert_eq!(result, "000Abc123Def456Ghi789");
+    }
 }
 
 #[cfg(test)]

--- a/src/caser.rs
+++ b/src/caser.rs
@@ -74,10 +74,24 @@ pub trait Caser<T: AsRef<str>> {
     /// ```rust
     ///     use stringcase::Caser;
     ///
-    ///     let cobol = "foo_bar_baz".to_cobol_case();
-    ///     assert_eq!(cobol, "FOO-BAR-BAZ");
+    ///     let cobol = "fooBar100Baz".to_cobol_case();
+    ///     assert_eq!(cobol, "FOO-BAR100-BAZ");
     /// ```
     fn to_cobol_case(&self) -> String;
+
+    /// Converts a string to cobol case.
+    ///
+    /// This method targets the upper and lower cases of ASCII alphabets and
+    /// ASCII numbers for capitalization, and all characters except ASCII
+    /// alphabets and ASCII numbers are replaced to hyphens as word separators.
+    ///
+    /// ```rust
+    ///     use stringcase::Caser;
+    ///
+    ///     let cobol = "fooBar100Baz".to_cobol_case_with_nums_as_word();
+    ///     assert_eq!(cobol, "FOO-BAR-100-BAZ");
+    /// ```
+    fn to_cobol_case_with_nums_as_word(&self) -> String;
 
     /// Converts a string to cobol case using the specified characters as
     /// separators.
@@ -117,7 +131,7 @@ pub trait Caser<T: AsRef<str>> {
     ///
     /// This method targets the upper and lower cases of ASCII alphabets for
     /// capitalization, and all characters except ASCII alphabets and ASCII numbers
-    /// are eliminated as word separators.
+    /// are replaced to hyphens as word separators.
     ///
     /// ```rust
     ///     use stringcase::Caser;
@@ -126,6 +140,20 @@ pub trait Caser<T: AsRef<str>> {
     ///     assert_eq!(kebab, "foo-bar100-baz");
     /// ```
     fn to_kebab_case(&self) -> String;
+
+    /// Converts a string to kebab case.
+    ///
+    /// This method targets the upper and lower cases of ASCII alphabets and
+    /// ASCII numbers for capitalization, and all characters except ASCII
+    /// alphabets and ASCII numbers are replaced to hyphens as word separators.
+    ///
+    /// ```rust
+    ///     use stringcase::Caser;
+    ///
+    ///     let kebab = "foo-bar100%baz".to_kebab_case_with_nums_as_word();
+    ///     assert_eq!(kebab, "foo-bar-100-baz");
+    /// ```
+    fn to_kebab_case_with_nums_as_word(&self) -> String;
 
     /// Converts a string to kebab case using the specified characters as
     /// separators.
@@ -164,7 +192,7 @@ pub trait Caser<T: AsRef<str>> {
     ///
     /// This method targets the upper and lower cases of ASCII alphabets for
     /// capitalization, and all characters except ASCII alphabets and ASCII numbers
-    /// are eliminated as word separators.
+    /// are replaced to underscores as word separators.
     ///
     /// ```rust
     ///     use stringcase::Caser;
@@ -173,6 +201,20 @@ pub trait Caser<T: AsRef<str>> {
     ///     assert_eq!(macro_, "FOO_BAR100_BAZ");
     /// ```
     fn to_macro_case(&self) -> String;
+
+    /// Converts a string to macro case.
+    ///
+    /// This method targets the upper and lower cases of ASCII alphabets and
+    /// ASCII numbers for capitalization, and all characters except ASCII
+    /// alphabets and ASCII numbers are replaced to underscores as word separators.
+    ///
+    /// ```rust
+    ///     use stringcase::Caser;
+    ///
+    ///     let macro_ = "foo-bar100%baz".to_macro_case_with_nums_as_word();
+    ///     assert_eq!(macro_, "FOO_BAR_100_BAZ");
+    /// ```
+    fn to_macro_case_with_nums_as_word(&self) -> String;
 
     /// Converts a string to macro case using the specified characters as
     /// separators.
@@ -258,7 +300,7 @@ pub trait Caser<T: AsRef<str>> {
     ///
     /// This method targets the upper and lower cases of ASCII alphabets for
     /// capitalization, and all characters except ASCII alphabets and ASCII numbers
-    /// are eliminated as word separators.
+    /// are replaced to underscores as word separators.
     ///
     /// ```rust
     ///     use stringcase::Caser;
@@ -267,6 +309,20 @@ pub trait Caser<T: AsRef<str>> {
     ///     assert_eq!(snake, "foo_bar100_baz");
     /// ```
     fn to_snake_case(&self) -> String;
+
+    /// Converts a string to snake case.
+    ///
+    /// This method targets the upper and lower cases of ASCII alphabets and
+    /// ASCII numbers for capitalization, and all characters except ASCII
+    /// alphabets and ASCII numbers are replaced to underscores as word separators.
+    ///
+    /// ```rust
+    ///     use stringcase::Caser;
+    ///
+    ///     let snake = "foo-bar100%baz".to_snake_case_with_nums_as_word();
+    ///     assert_eq!(snake, "foo_bar_100_baz");
+    /// ```
+    fn to_snake_case_with_nums_as_word(&self) -> String;
 
     /// Converts a string to snake case using the specified characters as
     /// separators.
@@ -305,7 +361,7 @@ pub trait Caser<T: AsRef<str>> {
     ///
     /// This method targets the upper and lower cases of ASCII alphabets for
     /// capitalization, and all characters except ASCII alphabets and ASCII numbers
-    /// are eliminated as word separators.
+    /// are replaced to hyphens as word separators.
     ///
     /// ```rust
     ///     use stringcase::Caser;
@@ -314,6 +370,20 @@ pub trait Caser<T: AsRef<str>> {
     ///     assert_eq!(train, "Foo-Bar100-Baz");
     /// ```
     fn to_train_case(&self) -> String;
+
+    /// Converts a string to train case.
+    ///
+    /// This method targets the upper and lower cases of ASCII alphabets and
+    /// ASCII numbers for capitalization, and all characters except ASCII alphabets
+    /// and ASCII numbers are replaced to hyphens as word separators.
+    ///
+    /// ```rust
+    ///     use stringcase::Caser;
+    ///
+    ///     let train = "foo-bar100%baz".to_train_case_with_nums_as_word();
+    ///     assert_eq!(train, "Foo-Bar-100-Baz");
+    /// ```
+    fn to_train_case_with_nums_as_word(&self) -> String;
 
     /// Converts a string to train case using the specified characters as
     /// separators.
@@ -368,6 +438,10 @@ impl<T: AsRef<str>> Caser<T> for T {
         cobol_case(&self.as_ref())
     }
 
+    fn to_cobol_case_with_nums_as_word(&self) -> String {
+        cobol_case_with_nums_as_word(&self.as_ref())
+    }
+
     fn to_cobol_case_with_sep(&self, seps: &str) -> String {
         cobol_case_with_sep(&self.as_ref(), seps)
     }
@@ -382,6 +456,10 @@ impl<T: AsRef<str>> Caser<T> for T {
         kebab_case(&self.as_ref())
     }
 
+    fn to_kebab_case_with_nums_as_word(&self) -> String {
+        kebab_case_with_nums_as_word(&self.as_ref())
+    }
+
     fn to_kebab_case_with_sep(&self, seps: &str) -> String {
         kebab_case_with_sep(&self.as_ref(), seps)
     }
@@ -394,6 +472,10 @@ impl<T: AsRef<str>> Caser<T> for T {
 
     fn to_macro_case(&self) -> String {
         macro_case(&self.as_ref())
+    }
+
+    fn to_macro_case_with_nums_as_word(&self) -> String {
+        macro_case_with_nums_as_word(&self.as_ref())
     }
 
     fn to_macro_case_with_sep(&self, seps: &str) -> String {
@@ -424,6 +506,10 @@ impl<T: AsRef<str>> Caser<T> for T {
         snake_case(&self.as_ref())
     }
 
+    fn to_snake_case_with_nums_as_word(&self) -> String {
+        snake_case_with_nums_as_word(&self.as_ref())
+    }
+
     fn to_snake_case_with_sep(&self, seps: &str) -> String {
         snake_case_with_sep(&self.as_ref(), seps)
     }
@@ -436,6 +522,10 @@ impl<T: AsRef<str>> Caser<T> for T {
 
     fn to_train_case(&self) -> String {
         train_case(&self.as_ref())
+    }
+
+    fn to_train_case_with_nums_as_word(&self) -> String {
+        train_case_with_nums_as_word(&self.as_ref())
     }
 
     fn to_train_case_with_sep(&self, seps: &str) -> String {
@@ -496,6 +586,16 @@ mod tests_of_caser {
     }
 
     #[test]
+    fn it_should_convert_to_cobol_case_with_nums_as_word() {
+        let result = "foo_bar100%BAZQux".to_cobol_case_with_nums_as_word();
+        assert_eq!(result, "FOO-BAR-100-BAZ-QUX");
+
+        let string = String::from("foo_bar100%BAZQux");
+        let result = string.to_cobol_case_with_nums_as_word();
+        assert_eq!(result, "FOO-BAR-100-BAZ-QUX");
+    }
+
+    #[test]
     fn it_should_convert_to_cobol_case_with_sep() {
         let result = "foo_bar100%BAZQux".to_cobol_case_with_sep("_");
         assert_eq!(result, "FOO-BAR100%-BAZ-QUX");
@@ -528,6 +628,16 @@ mod tests_of_caser {
     }
 
     #[test]
+    fn it_should_convert_to_kebab_case_with_nums_as_word() {
+        let result = "foo_bar100%BAZQux".to_kebab_case_with_nums_as_word();
+        assert_eq!(result, "foo-bar-100-baz-qux");
+
+        let string = String::from("foo_bar100%BAZQux");
+        let result = string.to_kebab_case_with_nums_as_word();
+        assert_eq!(result, "foo-bar-100-baz-qux");
+    }
+
+    #[test]
     fn it_should_convert_to_kebab_case_with_sep() {
         let result = "foo_bar100%BAZQux".to_kebab_case_with_sep("_");
         assert_eq!(result, "foo-bar100%-baz-qux");
@@ -557,6 +667,16 @@ mod tests_of_caser {
         let string = String::from("foo_bar100%BAZQux");
         let result = string.to_macro_case();
         assert_eq!(result, "FOO_BAR100_BAZ_QUX");
+    }
+
+    #[test]
+    fn it_should_convert_to_macro_case_with_nums_as_word() {
+        let result = "foo_bar100%BAZQux".to_macro_case_with_nums_as_word();
+        assert_eq!(result, "FOO_BAR_100_BAZ_QUX");
+
+        let string = String::from("foo_bar100%BAZQux");
+        let result = string.to_macro_case_with_nums_as_word();
+        assert_eq!(result, "FOO_BAR_100_BAZ_QUX");
     }
 
     #[test]
@@ -624,6 +744,16 @@ mod tests_of_caser {
     }
 
     #[test]
+    fn it_should_convert_to_snake_case_with_nums_as_word() {
+        let result = "foo_bar100%BAZQux".to_snake_case_with_nums_as_word();
+        assert_eq!(result, "foo_bar_100_baz_qux");
+
+        let string = String::from("foo_bar100%BAZQux");
+        let result = string.to_snake_case_with_nums_as_word();
+        assert_eq!(result, "foo_bar_100_baz_qux");
+    }
+
+    #[test]
     fn it_should_convert_to_snake_case_with_sep() {
         let result = "foo_bar100%BAZQux".to_snake_case_with_sep("_");
         assert_eq!(result, "foo_bar100%_baz_qux");
@@ -653,6 +783,16 @@ mod tests_of_caser {
         let string = String::from("foo_bar100%BAZQux");
         let result = string.to_train_case();
         assert_eq!(result, "Foo-Bar100-Baz-Qux");
+    }
+
+    #[test]
+    fn it_should_convert_to_train_case_with_nums_as_word() {
+        let result = "foo_bar100%BAZQux".to_train_case_with_nums_as_word();
+        assert_eq!(result, "Foo-Bar-100-Baz-Qux");
+
+        let string = String::from("foo_bar100%BAZQux");
+        let result = string.to_train_case_with_nums_as_word();
+        assert_eq!(result, "Foo-Bar-100-Baz-Qux");
     }
 
     #[test]

--- a/src/cobol_case.rs
+++ b/src/cobol_case.rs
@@ -12,8 +12,8 @@
 /// are replaced to hyphens as word separators.
 ///
 /// ```rust
-///     let cobol = stringcase::cobol_case("foo_bar_baz");
-///     assert_eq!(cobol, "FOO-BAR-BAZ");
+///     let cobol = stringcase::cobol_case("fooBar123Baz");
+///     assert_eq!(cobol, "FOO-BAR123-BAZ");
 /// ```
 pub fn cobol_case(input: &str) -> String {
     let mut result = String::with_capacity(input.len() + input.len() / 2);
@@ -66,6 +66,85 @@ pub fn cobol_case(input: &str) -> String {
             match flag {
                 ChIs::NextOfSepMark => result.push('-'),
                 _ => (),
+            }
+            result.push(ch);
+            flag = ChIs::NextOfKeepedMark;
+        } else {
+            match flag {
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfSepMark,
+            }
+        }
+    }
+
+    result
+}
+
+/// Converts a string to cobol case.
+///
+/// This function takes a string slice as its argument, then returns a `String`
+/// of which the case style is cobol case.
+///
+/// This function targets the upper and lower cases of ASCII alphabets and ASCII numbers
+/// for capitalization, and all characters except ASCII alphabets and ASCII numbers
+/// are replaced to hyphens as word separators.
+///
+/// ```rust
+///     let cobol = stringcase::cobol_case_with_nums_as_word("fooBar123Baz");
+///     assert_eq!(cobol, "FOO-BAR-123-BAZ");
+/// ```
+pub fn cobol_case_with_nums_as_word(input: &str) -> String {
+    let mut result = String::with_capacity(input.len() + input.len() / 2);
+    // .len returns byte count but ok in this case!
+
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfSepMark,
+        NextOfKeepedMark, // = next of number
+        Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
+
+    for ch in input.chars() {
+        if ch.is_ascii_uppercase() {
+            match flag {
+                ChIs::FirstOfStr => {
+                    result.push(ch);
+                    flag = ChIs::NextOfUpper;
+                }
+                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
+                    result.push(ch);
+                    flag = ChIs::NextOfContdUpper;
+                }
+                _ => {
+                    result.push('-');
+                    result.push(ch);
+                    flag = ChIs::NextOfUpper;
+                }
+            }
+        } else if ch.is_ascii_lowercase() {
+            match flag {
+                ChIs::NextOfContdUpper => match result.pop() {
+                    Some(prev) => {
+                        result.push('-');
+                        result.push(prev);
+                    }
+                    None => (), // impossible
+                },
+                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
+                    result.push('-');
+                }
+                _ => (),
+            }
+            result.push(ch.to_ascii_uppercase());
+            flag = ChIs::Others;
+        } else if ch.is_ascii_digit() {
+            match flag {
+                ChIs::FirstOfStr => (),
+                ChIs::NextOfKeepedMark => (),
+                _ => result.push('-'),
             }
             result.push(ch);
             flag = ChIs::NextOfKeepedMark;
@@ -310,6 +389,134 @@ mod tests_of_cobol_case {
     fn it_should_convert_empty() {
         let result = cobol_case("");
         assert_eq!(result, "");
+    }
+
+    #[test]
+    fn it_should_treat_number_sequence_by_default() {
+        let result = cobol_case("abc123Def456#Ghi789");
+        assert_eq!(result, "ABC123-DEF456-GHI789");
+
+        let result = cobol_case("ABC123-DEF456#GHI789");
+        assert_eq!(result, "ABC123-DEF456-GHI789");
+
+        let result = cobol_case("abc123-def456#ghi789");
+        assert_eq!(result, "ABC123-DEF456-GHI789");
+
+        let result = cobol_case("ABC123_DEF456#GHI789");
+        assert_eq!(result, "ABC123-DEF456-GHI789");
+
+        let result = cobol_case("Abc123Def456#Ghi789");
+        assert_eq!(result, "ABC123-DEF456-GHI789");
+
+        let result = cobol_case("abc123_def456#ghi789");
+        assert_eq!(result, "ABC123-DEF456-GHI789");
+
+        let result = cobol_case("Abc123-Def456#-Ghi789");
+        assert_eq!(result, "ABC123-DEF456-GHI789");
+
+        let result = cobol_case("000-abc123_def456#ghi789");
+        assert_eq!(result, "000-ABC123-DEF456-GHI789");
+    }
+}
+
+#[cfg(test)]
+mod tests_of_cobol_case_with_nums_as_word {
+    use super::*;
+
+    #[test]
+    fn it_should_convert_camel_case() {
+        let result = cobol_case_with_nums_as_word("abcDefGHIjk");
+        assert_eq!(result, "ABC-DEF-GH-IJK");
+    }
+
+    #[test]
+    fn it_should_convert_pascal_case() {
+        let result = cobol_case_with_nums_as_word("AbcDefGHIjk");
+        assert_eq!(result, "ABC-DEF-GH-IJK");
+    }
+
+    #[test]
+    fn it_should_convert_snake_case() {
+        let result = cobol_case_with_nums_as_word("abc_def_ghi");
+        assert_eq!(result, "ABC-DEF-GHI");
+    }
+
+    #[test]
+    fn it_should_convert_kebab_case() {
+        let result = cobol_case_with_nums_as_word("abc-def-ghi");
+        assert_eq!(result, "ABC-DEF-GHI");
+    }
+
+    #[test]
+    fn it_should_convert_train_case() {
+        let result = cobol_case_with_nums_as_word("Abc-Def-Ghi");
+        assert_eq!(result, "ABC-DEF-GHI");
+    }
+
+    #[test]
+    fn it_should_convert_macro_case() {
+        let result = cobol_case_with_nums_as_word("ABC_DEF_GHI");
+        assert_eq!(result, "ABC-DEF-GHI");
+    }
+
+    #[test]
+    fn it_should_convert_cobol_case() {
+        let result = cobol_case_with_nums_as_word("ABC-DEF-GHI");
+        assert_eq!(result, "ABC-DEF-GHI");
+    }
+
+    #[test]
+    fn it_should_keep_digits() {
+        let result = cobol_case_with_nums_as_word("abc123-456defG789HIJklMN12");
+        assert_eq!(result, "ABC-123-456-DEF-G-789-HI-JKL-MN-12");
+    }
+
+    #[test]
+    fn it_should_convert_when_starting_with_digit() {
+        let result = cobol_case_with_nums_as_word("123abc456def");
+        assert_eq!(result, "123-ABC-456-DEF");
+
+        let result = cobol_case_with_nums_as_word("123ABC456DEF");
+        assert_eq!(result, "123-ABC-456-DEF");
+    }
+
+    #[test]
+    fn it_should_treat_marks_as_separators() {
+        let result = cobol_case_with_nums_as_word(":.abc~!@def#$ghi%&jk(lm)no/?");
+        assert_eq!(result, "ABC-DEF-GHI-JK-LM-NO");
+    }
+
+    #[test]
+    fn it_should_convert_empty() {
+        let result = cobol_case_with_nums_as_word("");
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn it_should_treat_number_sequence_as_word() {
+        let result = cobol_case_with_nums_as_word("abc123Def456#Ghi789");
+        assert_eq!(result, "ABC-123-DEF-456-GHI-789");
+
+        let result = cobol_case_with_nums_as_word("ABC123-DEF456#GHI789");
+        assert_eq!(result, "ABC-123-DEF-456-GHI-789");
+
+        let result = cobol_case_with_nums_as_word("abc123-def456#ghi789");
+        assert_eq!(result, "ABC-123-DEF-456-GHI-789");
+
+        let result = cobol_case_with_nums_as_word("ABC123_DEF456#GHI789");
+        assert_eq!(result, "ABC-123-DEF-456-GHI-789");
+
+        let result = cobol_case_with_nums_as_word("Abc123Def456#Ghi789");
+        assert_eq!(result, "ABC-123-DEF-456-GHI-789");
+
+        let result = cobol_case_with_nums_as_word("abc123_def456#ghi789");
+        assert_eq!(result, "ABC-123-DEF-456-GHI-789");
+
+        let result = cobol_case_with_nums_as_word("Abc123-Def456#-Ghi789");
+        assert_eq!(result, "ABC-123-DEF-456-GHI-789");
+
+        let result = cobol_case_with_nums_as_word("000-abc123_def456#ghi789");
+        assert_eq!(result, "000-ABC-123-DEF-456-GHI-789");
     }
 }
 

--- a/src/kebab_case.rs
+++ b/src/kebab_case.rs
@@ -9,11 +9,11 @@
 ///
 /// This function targets the upper and lower cases of ASCII alphabets for
 /// capitalization, and all characters except ASCII alphabets and ASCII numbers
-/// are eliminated as word separators.
+/// are replaced to hyphens as word separators.
 ///
 /// ```rust
-///     let kebab = stringcase::kebab_case("fooBarBaz");
-///     assert_eq!(kebab, "foo-bar-baz");
+///     let kebab = stringcase::kebab_case("fooBar123Baz");
+///     assert_eq!(kebab, "foo-bar123-baz");
 /// ```
 pub fn kebab_case(input: &str) -> String {
     let mut result = String::with_capacity(input.len() + input.len() / 2);
@@ -66,6 +66,85 @@ pub fn kebab_case(input: &str) -> String {
             match flag {
                 ChIs::NextOfSepMark => result.push('-'),
                 _ => (),
+            }
+            result.push(ch);
+            flag = ChIs::NextOfKeepedMark;
+        } else {
+            match flag {
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfSepMark,
+            }
+        }
+    }
+
+    result
+}
+
+/// Converts a string to kebab case.
+///
+/// This function takes a string slice as its argument, then returns a `String`
+/// of which the case style is kebab case.
+///
+/// This function targets the upper and lower cases of ASCII alphabets and ASCII numbers
+/// for capitalization, and all characters except ASCII alphabets and ASCII numbers
+/// are replaced to hyphens as word separators.
+///
+/// ```rust
+///     let kebab = stringcase::kebab_case_with_nums_as_word("fooBar123Baz");
+///     assert_eq!(kebab, "foo-bar-123-baz");
+/// ```
+pub fn kebab_case_with_nums_as_word(input: &str) -> String {
+    let mut result = String::with_capacity(input.len() + input.len() / 2);
+    // .len returns byte count but ok in this case!
+
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfSepMark,
+        NextOfKeepedMark, // = next of number
+        Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
+
+    for ch in input.chars() {
+        if ch.is_ascii_uppercase() {
+            match flag {
+                ChIs::FirstOfStr => {
+                    result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::NextOfUpper;
+                }
+                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
+                    result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::NextOfContdUpper;
+                }
+                _ => {
+                    result.push('-');
+                    result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::NextOfUpper;
+                }
+            }
+        } else if ch.is_ascii_lowercase() {
+            match flag {
+                ChIs::NextOfContdUpper => match result.pop() {
+                    Some(prev) => {
+                        result.push('-');
+                        result.push(prev);
+                    }
+                    None => (), // impossible
+                },
+                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
+                    result.push('-');
+                }
+                _ => (),
+            }
+            result.push(ch);
+            flag = ChIs::Others;
+        } else if ch.is_ascii_digit() {
+            match flag {
+                ChIs::FirstOfStr => (),
+                ChIs::NextOfKeepedMark => (),
+                _ => result.push('-'),
             }
             result.push(ch);
             flag = ChIs::NextOfKeepedMark;
@@ -310,6 +389,134 @@ mod tests_of_kebab_case {
     fn it_should_convert_empty() {
         let result = kebab_case("");
         assert_eq!(result, "");
+    }
+
+    #[test]
+    fn it_should_treat_number_sequence_by_default() {
+        let result = kebab_case("abc123Def456#Ghi789");
+        assert_eq!(result, "abc123-def456-ghi789");
+
+        let result = kebab_case("ABC123-DEF456#GHI789");
+        assert_eq!(result, "abc123-def456-ghi789");
+
+        let result = kebab_case("abc123-def456#ghi789");
+        assert_eq!(result, "abc123-def456-ghi789");
+
+        let result = kebab_case("ABC123_DEF456#GHI789");
+        assert_eq!(result, "abc123-def456-ghi789");
+
+        let result = kebab_case("Abc123Def456#Ghi789");
+        assert_eq!(result, "abc123-def456-ghi789");
+
+        let result = kebab_case("abc123_def456#ghi789");
+        assert_eq!(result, "abc123-def456-ghi789");
+
+        let result = kebab_case("Abc123-Def456#-Ghi789");
+        assert_eq!(result, "abc123-def456-ghi789");
+
+        let result = kebab_case("000-abc123_def456#ghi789");
+        assert_eq!(result, "000-abc123-def456-ghi789");
+    }
+}
+
+#[cfg(test)]
+mod tests_of_kebab_case_with_nums_as_word {
+    use super::*;
+
+    #[test]
+    fn it_should_convert_camel_case() {
+        let result = kebab_case_with_nums_as_word("abcDefGHIjk");
+        assert_eq!(result, "abc-def-gh-ijk");
+    }
+
+    #[test]
+    fn it_should_convert_pascal_case() {
+        let result = kebab_case_with_nums_as_word("AbcDefGHIjk");
+        assert_eq!(result, "abc-def-gh-ijk");
+    }
+
+    #[test]
+    fn it_should_convert_snake_case() {
+        let result = kebab_case_with_nums_as_word("abc_def_ghi");
+        assert_eq!(result, "abc-def-ghi");
+    }
+
+    #[test]
+    fn it_should_convert_kebab_case() {
+        let result = kebab_case_with_nums_as_word("abc-def-ghi");
+        assert_eq!(result, "abc-def-ghi");
+    }
+
+    #[test]
+    fn it_should_convert_train_case() {
+        let result = kebab_case_with_nums_as_word("Abc-Def-Ghi");
+        assert_eq!(result, "abc-def-ghi");
+    }
+
+    #[test]
+    fn it_should_convert_macro_case() {
+        let result = kebab_case_with_nums_as_word("ABC_DEF_GHI");
+        assert_eq!(result, "abc-def-ghi");
+    }
+
+    #[test]
+    fn it_should_convert_cobol_case() {
+        let result = kebab_case_with_nums_as_word("ABC-DEF-GHI");
+        assert_eq!(result, "abc-def-ghi");
+    }
+
+    #[test]
+    fn it_should_keep_digits() {
+        let result = kebab_case_with_nums_as_word("abc123-456defG789HIJklMN12");
+        assert_eq!(result, "abc-123-456-def-g-789-hi-jkl-mn-12");
+    }
+
+    #[test]
+    fn it_should_convert_when_starting_with_digit() {
+        let result = kebab_case_with_nums_as_word("123abc456def");
+        assert_eq!(result, "123-abc-456-def");
+
+        let result = kebab_case_with_nums_as_word("123ABC456DEF");
+        assert_eq!(result, "123-abc-456-def");
+    }
+
+    #[test]
+    fn it_should_treat_marks_as_separators() {
+        let result = kebab_case_with_nums_as_word(":.abc~!@def#$ghi%&jk(lm)no/?");
+        assert_eq!(result, "abc-def-ghi-jk-lm-no");
+    }
+
+    #[test]
+    fn it_should_convert_empty() {
+        let result = kebab_case_with_nums_as_word("");
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn it_should_treat_number_sequence_as_word() {
+        let result = kebab_case_with_nums_as_word("abc123Def456#Ghi789");
+        assert_eq!(result, "abc-123-def-456-ghi-789");
+
+        let result = kebab_case_with_nums_as_word("ABC123-DEF456#GHI789");
+        assert_eq!(result, "abc-123-def-456-ghi-789");
+
+        let result = kebab_case_with_nums_as_word("abc123-def456#ghi789");
+        assert_eq!(result, "abc-123-def-456-ghi-789");
+
+        let result = kebab_case_with_nums_as_word("ABC123_DEF456#GHI789");
+        assert_eq!(result, "abc-123-def-456-ghi-789");
+
+        let result = kebab_case_with_nums_as_word("Abc123Def456#Ghi789");
+        assert_eq!(result, "abc-123-def-456-ghi-789");
+
+        let result = kebab_case_with_nums_as_word("abc123_def456#ghi789");
+        assert_eq!(result, "abc-123-def-456-ghi-789");
+
+        let result = kebab_case_with_nums_as_word("Abc123-Def456#-Ghi789");
+        assert_eq!(result, "abc-123-def-456-ghi-789");
+
+        let result = kebab_case_with_nums_as_word("000-abc123_def456#ghi789");
+        assert_eq!(result, "000-abc-123-def-456-ghi-789");
     }
 }
 

--- a/src/macro_case.rs
+++ b/src/macro_case.rs
@@ -9,11 +9,11 @@
 ///
 /// This function targets the upper and lower cases of ASCII alphabets for
 /// capitalization, and all characters except ASCII alphabets and ASCII numbers
-/// are eliminated as word separators.
+/// are replaced to underscores as word separators.
 ///
 /// ```rust
-///     let m = stringcase::macro_case("fooBarBaz");
-///     assert_eq!(m, "FOO_BAR_BAZ");
+///     let m = stringcase::macro_case("fooBar123Baz");
+///     assert_eq!(m, "FOO_BAR123_BAZ");
 /// ```
 pub fn macro_case(input: &str) -> String {
     let mut result = String::with_capacity(input.len() + input.len() / 2);
@@ -66,6 +66,85 @@ pub fn macro_case(input: &str) -> String {
             match flag {
                 ChIs::NextOfSepMark => result.push('_'),
                 _ => (),
+            }
+            result.push(ch);
+            flag = ChIs::NextOfKeepedMark;
+        } else {
+            match flag {
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfSepMark,
+            }
+        }
+    }
+
+    result
+}
+
+/// Converts a string to macro case.
+///
+/// This function takes a string slice as its argument, then returns a `String`
+/// of which the case style is macro case.
+///
+/// This function targets the upper and lower cases of ASCII alphabets and ASCII numbers
+/// for capitalization, and all characters except ASCII alphabets and ASCII numbers
+/// are replaced to underscores as word separators.
+///
+/// ```rust
+///     let m = stringcase::macro_case_with_nums_as_word("fooBar123Baz");
+///     assert_eq!(m, "FOO_BAR_123_BAZ");
+/// ```
+pub fn macro_case_with_nums_as_word(input: &str) -> String {
+    let mut result = String::with_capacity(input.len() + input.len() / 2);
+    // .len returns byte count but ok in this case!
+
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfSepMark,
+        NextOfKeepedMark, // = next of number
+        Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
+
+    for ch in input.chars() {
+        if ch.is_ascii_uppercase() {
+            match flag {
+                ChIs::FirstOfStr => {
+                    result.push(ch);
+                    flag = ChIs::NextOfUpper;
+                }
+                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
+                    result.push(ch);
+                    flag = ChIs::NextOfContdUpper;
+                }
+                _ => {
+                    result.push('_');
+                    result.push(ch);
+                    flag = ChIs::NextOfUpper;
+                }
+            }
+        } else if ch.is_ascii_lowercase() {
+            match flag {
+                ChIs::NextOfContdUpper => match result.pop() {
+                    Some(prev) => {
+                        result.push('_');
+                        result.push(prev);
+                    }
+                    None => (), // impossible
+                },
+                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
+                    result.push('_');
+                }
+                _ => (),
+            }
+            result.push(ch.to_ascii_uppercase());
+            flag = ChIs::Others;
+        } else if ch.is_ascii_digit() {
+            match flag {
+                ChIs::FirstOfStr => (),
+                ChIs::NextOfKeepedMark => (),
+                _ => result.push('_'),
             }
             result.push(ch);
             flag = ChIs::NextOfKeepedMark;
@@ -310,6 +389,134 @@ mod tests_of_macro_case {
     fn it_should_convert_empty() {
         let result = macro_case("");
         assert_eq!(result, "");
+    }
+
+    #[test]
+    fn it_should_treat_number_sequence_by_default() {
+        let result = macro_case("abc123Def456#Ghi789");
+        assert_eq!(result, "ABC123_DEF456_GHI789");
+
+        let result = macro_case("ABC123-DEF456#GHI789");
+        assert_eq!(result, "ABC123_DEF456_GHI789");
+
+        let result = macro_case("abc123-def456#ghi789");
+        assert_eq!(result, "ABC123_DEF456_GHI789");
+
+        let result = macro_case("ABC123_DEF456#GHI789");
+        assert_eq!(result, "ABC123_DEF456_GHI789");
+
+        let result = macro_case("Abc123Def456#Ghi789");
+        assert_eq!(result, "ABC123_DEF456_GHI789");
+
+        let result = macro_case("abc123_def456#ghi789");
+        assert_eq!(result, "ABC123_DEF456_GHI789");
+
+        let result = macro_case("Abc123-Def456#-Ghi789");
+        assert_eq!(result, "ABC123_DEF456_GHI789");
+
+        let result = macro_case("000-abc123_def456#ghi789");
+        assert_eq!(result, "000_ABC123_DEF456_GHI789");
+    }
+}
+
+#[cfg(test)]
+mod tests_of_macro_case_with_nums_as_word {
+    use super::*;
+
+    #[test]
+    fn it_should_convert_camel_case() {
+        let result = macro_case_with_nums_as_word("abcDefGHIjk");
+        assert_eq!(result, "ABC_DEF_GH_IJK");
+    }
+
+    #[test]
+    fn it_should_convert_pascal_case() {
+        let result = macro_case_with_nums_as_word("AbcDefGHIjk");
+        assert_eq!(result, "ABC_DEF_GH_IJK");
+    }
+
+    #[test]
+    fn it_should_convert_snake_case() {
+        let result = macro_case_with_nums_as_word("abc_def_ghi");
+        assert_eq!(result, "ABC_DEF_GHI");
+    }
+
+    #[test]
+    fn it_should_convert_kebab_case() {
+        let result = macro_case_with_nums_as_word("abc-def-ghi");
+        assert_eq!(result, "ABC_DEF_GHI");
+    }
+
+    #[test]
+    fn it_should_convert_train_case() {
+        let result = macro_case_with_nums_as_word("Abc-Def-Ghi");
+        assert_eq!(result, "ABC_DEF_GHI");
+    }
+
+    #[test]
+    fn it_should_convert_macro_case() {
+        let result = macro_case_with_nums_as_word("ABC_DEF_GHI");
+        assert_eq!(result, "ABC_DEF_GHI");
+    }
+
+    #[test]
+    fn it_should_convert_cobol_case() {
+        let result = macro_case_with_nums_as_word("ABC-DEF-GHI");
+        assert_eq!(result, "ABC_DEF_GHI");
+    }
+
+    #[test]
+    fn it_should_keep_digits() {
+        let result = macro_case_with_nums_as_word("abc123-456defG89HIJklMN12");
+        assert_eq!(result, "ABC_123_456_DEF_G_89_HI_JKL_MN_12");
+    }
+
+    #[test]
+    fn it_should_convert_when_starting_with_digit() {
+        let result = macro_case_with_nums_as_word("123abc456def");
+        assert_eq!(result, "123_ABC_456_DEF");
+
+        let result = macro_case_with_nums_as_word("123ABC456DEF");
+        assert_eq!(result, "123_ABC_456_DEF");
+    }
+
+    #[test]
+    fn it_should_treat_marks_as_separators() {
+        let result = macro_case_with_nums_as_word(":.abc~!@def#$ghi%&jk(lm)no/?");
+        assert_eq!(result, "ABC_DEF_GHI_JK_LM_NO");
+    }
+
+    #[test]
+    fn it_should_convert_empty() {
+        let result = macro_case_with_nums_as_word("");
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn it_should_treat_number_sequence_as_word() {
+        let result = macro_case_with_nums_as_word("abc123Def456#Ghi789");
+        assert_eq!(result, "ABC_123_DEF_456_GHI_789");
+
+        let result = macro_case_with_nums_as_word("ABC123-DEF456#GHI789");
+        assert_eq!(result, "ABC_123_DEF_456_GHI_789");
+
+        let result = macro_case_with_nums_as_word("abc123-def456#ghi789");
+        assert_eq!(result, "ABC_123_DEF_456_GHI_789");
+
+        let result = macro_case_with_nums_as_word("ABC123_DEF456#GHI789");
+        assert_eq!(result, "ABC_123_DEF_456_GHI_789");
+
+        let result = macro_case_with_nums_as_word("Abc123Def456#Ghi789");
+        assert_eq!(result, "ABC_123_DEF_456_GHI_789");
+
+        let result = macro_case_with_nums_as_word("abc123_def456#ghi789");
+        assert_eq!(result, "ABC_123_DEF_456_GHI_789");
+
+        let result = macro_case_with_nums_as_word("Abc123-Def456#-Ghi789");
+        assert_eq!(result, "ABC_123_DEF_456_GHI_789");
+
+        let result = macro_case_with_nums_as_word("000-abc123_def456#ghi789");
+        assert_eq!(result, "000_ABC_123_DEF_456_GHI_789");
     }
 }
 

--- a/src/pascal_case.rs
+++ b/src/pascal_case.rs
@@ -287,6 +287,60 @@ mod tests_of_pascal_case {
         let result = pascal_case("");
         assert_eq!(result, "");
     }
+
+    #[test]
+    fn it_should_treat_number_sequence_by_default() {
+        let result = pascal_case("abc123Def456#Ghi789");
+        assert_eq!(result, "Abc123Def456Ghi789");
+
+        let result = pascal_case("ABC123-DEF456#GHI789");
+        assert_eq!(result, "Abc123Def456Ghi789");
+
+        let result = pascal_case("abc123-def456#ghi789");
+        assert_eq!(result, "Abc123Def456Ghi789");
+
+        let result = pascal_case("ABC123_DEF456#GHI789");
+        assert_eq!(result, "Abc123Def456Ghi789");
+
+        let result = pascal_case("Abc123Def456#Ghi789");
+        assert_eq!(result, "Abc123Def456Ghi789");
+
+        let result = pascal_case("abc123_def456#ghi789");
+        assert_eq!(result, "Abc123Def456Ghi789");
+
+        let result = pascal_case("Abc123-Def456#-Ghi789");
+        assert_eq!(result, "Abc123Def456Ghi789");
+
+        let result = pascal_case("000-abc123_def456#ghi789");
+        assert_eq!(result, "000Abc123Def456Ghi789");
+    }
+
+    #[test]
+    fn it_should_treat_number_sequence_as_word() {
+        let result = pascal_case("abc123Def456#Ghi789");
+        assert_eq!(result, "Abc123Def456Ghi789");
+
+        let result = pascal_case("ABC-123-DEF-456#GHI-789");
+        assert_eq!(result, "Abc123Def456Ghi789");
+
+        let result = pascal_case("abc-123-def-456#ghi-789");
+        assert_eq!(result, "Abc123Def456Ghi789");
+
+        let result = pascal_case("ABC_123_DEF_456#GHI_789");
+        assert_eq!(result, "Abc123Def456Ghi789");
+
+        let result = pascal_case("Abc123Def456#Ghi789");
+        assert_eq!(result, "Abc123Def456Ghi789");
+
+        let result = pascal_case("abc_123_def_456#ghi_789");
+        assert_eq!(result, "Abc123Def456Ghi789");
+
+        let result = pascal_case("Abc-123-Def-456#Ghi-789");
+        assert_eq!(result, "Abc123Def456Ghi789");
+
+        let result = pascal_case("000_abc_123_def_456#ghi_789");
+        assert_eq!(result, "000Abc123Def456Ghi789");
+    }
 }
 
 #[cfg(test)]

--- a/src/train_case.rs
+++ b/src/train_case.rs
@@ -9,11 +9,11 @@
 ///
 /// This function targets the upper and lower cases of ASCII alphabets for
 /// capitalization, and all characters except ASCII alphabets and ASCII numbers
-/// are eliminated as word separators.
+/// are replaced to hyphens as word separators.
 ///
 /// ```rust
-///     let train = stringcase::train_case("fooBarBaz");
-///     assert_eq!(train, "Foo-Bar-Baz");
+///     let train = stringcase::train_case("fooBar123Baz");
+///     assert_eq!(train, "Foo-Bar123-Baz");
 /// ```
 pub fn train_case(input: &str) -> String {
     let mut result = String::with_capacity(input.len() * 2);
@@ -72,6 +72,91 @@ pub fn train_case(input: &str) -> String {
             match flag {
                 ChIs::NextOfSepMark => result.push('-'),
                 _ => (),
+            }
+            result.push(ch);
+            flag = ChIs::NextOfKeepedMark;
+        } else {
+            match flag {
+                ChIs::FirstOfStr => (),
+                _ => flag = ChIs::NextOfSepMark,
+            }
+        }
+    }
+
+    result
+}
+
+/// Converts a string to train case.
+///
+/// This function takes a string slice as its argument, then returns a `String`
+/// of which the case style is train case.
+///
+/// This function targets the upper and lower cases of ASCII alphabets and ASCII numbers
+/// for capitalization, and all characters except ASCII alphabets and ASCII numbers
+/// are replaced to hyphens as word separators.
+///
+/// ```rust
+///     let train = stringcase::train_case_with_nums_as_word("fooBar123Baz");
+///     assert_eq!(train, "Foo-Bar-123-Baz");
+/// ```
+pub fn train_case_with_nums_as_word(input: &str) -> String {
+    let mut result = String::with_capacity(input.len() * 2);
+    // .len returns byte count but ok in this case!
+
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfSepMark,
+        NextOfKeepedMark, // = next of number
+        Others,
+    }
+    let mut flag = ChIs::FirstOfStr;
+
+    for ch in input.chars() {
+        if ch.is_ascii_uppercase() {
+            match flag {
+                ChIs::FirstOfStr => {
+                    result.push(ch);
+                    flag = ChIs::NextOfUpper;
+                }
+                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
+                    result.push(ch.to_ascii_lowercase());
+                    flag = ChIs::NextOfContdUpper;
+                }
+                _ => {
+                    result.push('-');
+                    result.push(ch);
+                    flag = ChIs::NextOfUpper;
+                }
+            }
+        } else if ch.is_ascii_lowercase() {
+            match flag {
+                ChIs::FirstOfStr => {
+                    result.push(ch.to_ascii_uppercase());
+                }
+                ChIs::NextOfContdUpper => match result.pop() {
+                    Some(prev) => {
+                        result.push('-');
+                        result.push(prev.to_ascii_uppercase());
+                        result.push(ch);
+                    }
+                    None => (), // impossible
+                },
+                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
+                    result.push('-');
+                    result.push(ch.to_ascii_uppercase());
+                }
+                _ => {
+                    result.push(ch);
+                }
+            }
+            flag = ChIs::Others;
+        } else if ch.is_ascii_digit() {
+            match flag {
+                ChIs::FirstOfStr => (),
+                ChIs::NextOfKeepedMark => (),
+                _ => result.push('-'),
             }
             result.push(ch);
             flag = ChIs::NextOfKeepedMark;
@@ -328,6 +413,134 @@ mod tests_of_train_case {
     fn it_should_convert_empty() {
         let result = train_case("");
         assert_eq!(result, "");
+    }
+
+    #[test]
+    fn it_should_treat_number_sequence_by_default() {
+        let result = train_case("abc123Def456#Ghi789");
+        assert_eq!(result, "Abc123-Def456-Ghi789");
+
+        let result = train_case("ABC123-DEF456#GHI789");
+        assert_eq!(result, "Abc123-Def456-Ghi789");
+
+        let result = train_case("abc123-def456#ghi789");
+        assert_eq!(result, "Abc123-Def456-Ghi789");
+
+        let result = train_case("ABC123_DEF456#GHI789");
+        assert_eq!(result, "Abc123-Def456-Ghi789");
+
+        let result = train_case("Abc123Def456#Ghi789");
+        assert_eq!(result, "Abc123-Def456-Ghi789");
+
+        let result = train_case("abc123_def456#ghi789");
+        assert_eq!(result, "Abc123-Def456-Ghi789");
+
+        let result = train_case("Abc123-Def456#-Ghi789");
+        assert_eq!(result, "Abc123-Def456-Ghi789");
+
+        let result = train_case("000-abc123_def456#ghi789");
+        assert_eq!(result, "000-Abc123-Def456-Ghi789");
+    }
+}
+
+#[cfg(test)]
+mod tests_of_train_case_with_nums_as_word {
+    use super::*;
+
+    #[test]
+    fn it_should_convert_camel_case() {
+        let result = train_case_with_nums_as_word("abcDefGHIjk");
+        assert_eq!(result, "Abc-Def-Gh-Ijk");
+    }
+
+    #[test]
+    fn it_should_convert_pascal_case() {
+        let result = train_case_with_nums_as_word("AbcDefGHIjk");
+        assert_eq!(result, "Abc-Def-Gh-Ijk");
+    }
+
+    #[test]
+    fn it_should_convert_snake_case() {
+        let result = train_case_with_nums_as_word("abc_def_ghi");
+        assert_eq!(result, "Abc-Def-Ghi");
+    }
+
+    #[test]
+    fn it_should_convert_kebab_case() {
+        let result = train_case_with_nums_as_word("abc-def-ghi");
+        assert_eq!(result, "Abc-Def-Ghi");
+    }
+
+    #[test]
+    fn it_should_convert_train_case() {
+        let result = train_case_with_nums_as_word("Abc-Def-Ghi");
+        assert_eq!(result, "Abc-Def-Ghi");
+    }
+
+    #[test]
+    fn it_should_convert_macro_case() {
+        let result = train_case_with_nums_as_word("ABC_DEF_GHI");
+        assert_eq!(result, "Abc-Def-Ghi");
+    }
+
+    #[test]
+    fn it_should_convert_cobol_case() {
+        let result = train_case_with_nums_as_word("ABC-DEF-GHI");
+        assert_eq!(result, "Abc-Def-Ghi");
+    }
+
+    #[test]
+    fn it_should_keep_digits() {
+        let result = train_case_with_nums_as_word("abc123-456defG789HIJklMN12");
+        assert_eq!(result, "Abc-123-456-Def-G-789-Hi-Jkl-Mn-12");
+    }
+
+    #[test]
+    fn it_should_convert_when_starting_with_digit() {
+        let result = train_case_with_nums_as_word("123abc456def");
+        assert_eq!(result, "123-Abc-456-Def");
+
+        let result = train_case_with_nums_as_word("123ABC456DEF");
+        assert_eq!(result, "123-Abc-456-Def");
+    }
+
+    #[test]
+    fn it_should_treat_marks_as_separators() {
+        let result = train_case_with_nums_as_word(":.abc~!@def#$ghi%&jk(lm)no/?");
+        assert_eq!(result, "Abc-Def-Ghi-Jk-Lm-No");
+    }
+
+    #[test]
+    fn it_should_convert_empty() {
+        let result = train_case_with_nums_as_word("");
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn it_should_treat_number_sequence_as_word() {
+        let result = train_case_with_nums_as_word("abc123Def456#Ghi789");
+        assert_eq!(result, "Abc-123-Def-456-Ghi-789");
+
+        let result = train_case_with_nums_as_word("ABC123-DEF456#GHI789");
+        assert_eq!(result, "Abc-123-Def-456-Ghi-789");
+
+        let result = train_case_with_nums_as_word("abc123-def456#ghi789");
+        assert_eq!(result, "Abc-123-Def-456-Ghi-789");
+
+        let result = train_case_with_nums_as_word("ABC123_DEF456#GHI789");
+        assert_eq!(result, "Abc-123-Def-456-Ghi-789");
+
+        let result = train_case_with_nums_as_word("Abc123Def456#Ghi789");
+        assert_eq!(result, "Abc-123-Def-456-Ghi-789");
+
+        let result = train_case_with_nums_as_word("abc123_def456#ghi789");
+        assert_eq!(result, "Abc-123-Def-456-Ghi-789");
+
+        let result = train_case_with_nums_as_word("Abc123-Def456#-Ghi789");
+        assert_eq!(result, "Abc-123-Def-456-Ghi-789");
+
+        let result = train_case_with_nums_as_word("000-abc123_def456#ghi789");
+        assert_eq!(result, "000-Abc-123-Def-456-Ghi-789");
     }
 }
 

--- a/tests/caser_test.rs
+++ b/tests/caser_test.rs
@@ -25,6 +25,12 @@ fn it_should_convert_to_cobol_case_by_method_of_string() {
 }
 
 #[test]
+fn it_should_convert_to_cobol_case_with_nums_as_word_by_method_of_string() {
+    let converted = "foo_bar100BAZQux".to_cobol_case_with_nums_as_word();
+    assert_eq!(converted, "FOO-BAR-100-BAZ-QUX");
+}
+
+#[test]
 fn it_should_convert_to_cobol_case_with_sep_by_method_of_string() {
     let converted = "foo_bar100BAZQux".to_cobol_case_with_sep("_");
     assert_eq!(converted, "FOO-BAR100-BAZ-QUX");
@@ -43,6 +49,12 @@ fn it_should_convert_to_kebab_case_by_method_of_string() {
 }
 
 #[test]
+fn it_should_convert_to_kebab_case_with_nums_as_word_by_method_of_string() {
+    let converted = "foo_bar100BAZQux".to_kebab_case_with_nums_as_word();
+    assert_eq!(converted, "foo-bar-100-baz-qux");
+}
+
+#[test]
 fn it_should_convert_to_kebab_case_with_sep_by_method_of_string() {
     let converted = "foo_bar100BAZQux".to_kebab_case_with_sep("_");
     assert_eq!(converted, "foo-bar100-baz-qux");
@@ -58,6 +70,12 @@ fn it_should_convert_to_kebab_case_with_keep_by_method_of_string() {
 fn it_should_convert_to_macro_case_by_method_of_string() {
     let converted = "foo_bar100BAZQux".to_macro_case();
     assert_eq!(converted, "FOO_BAR100_BAZ_QUX");
+}
+
+#[test]
+fn it_should_convert_to_macro_case_with_nums_as_word_by_method_of_string() {
+    let converted = "foo_bar100BAZQux".to_macro_case_with_nums_as_word();
+    assert_eq!(converted, "FOO_BAR_100_BAZ_QUX");
 }
 
 #[test]
@@ -97,6 +115,12 @@ fn it_should_convert_to_snake_case_by_method_of_string() {
 }
 
 #[test]
+fn it_should_convert_to_snake_case_with_nums_as_word_by_method_of_string() {
+    let converted = "foo_bar100BAZQux".to_snake_case_with_nums_as_word();
+    assert_eq!(converted, "foo_bar_100_baz_qux");
+}
+
+#[test]
 fn it_should_convert_to_snake_case_with_sep_by_method_of_string() {
     let converted = "foo_bar100BAZQux".to_snake_case_with_sep("_");
     assert_eq!(converted, "foo_bar100_baz_qux");
@@ -112,6 +136,12 @@ fn it_should_convert_to_snake_case_with_keep_by_method_of_string() {
 fn it_should_convert_to_train_case_by_method_of_string() {
     let converted = "foo_bar100BAZQux".to_train_case();
     assert_eq!(converted, "Foo-Bar100-Baz-Qux");
+}
+
+#[test]
+fn it_should_convert_to_train_case_with_nums_as_word_by_method_of_string() {
+    let converted = "foo_bar100BAZQux".to_train_case_with_nums_as_word();
+    assert_eq!(converted, "Foo-Bar-100-Baz-Qux");
 }
 
 #[test]

--- a/tests/cobol_case_test.rs
+++ b/tests/cobol_case_test.rs
@@ -17,3 +17,11 @@ fn it_should_convert_to_cobol_case_with_keep() {
     let converted = cobol_case_with_keep("foo_bar100%BAZQux", "%");
     assert_eq!(converted, "FOO-BAR100%-BAZ-QUX");
 }
+
+#[test]
+fn it_should_convert_to_cobol_case_with_nums_as_word() {
+    use stringcase::cobol_case_with_nums_as_word as cobol_case;
+
+    let converted = cobol_case("foo_bar100%BAZQux");
+    assert_eq!(converted, "FOO-BAR-100-BAZ-QUX");
+}

--- a/tests/kebab_case_test.rs
+++ b/tests/kebab_case_test.rs
@@ -17,3 +17,11 @@ fn it_should_convert_to_kebab_case_with_keep() {
     let converted = kebab_case_with_keep("foo_bar100%BAZQux", "%");
     assert_eq!(converted, "foo-bar100%-baz-qux");
 }
+
+#[test]
+fn it_should_convert_to_kebab_case_with_nums_as_word() {
+    use stringcase::kebab_case_with_nums_as_word as kebab_case;
+
+    let converted = kebab_case("foo-bar100%-baz-qux");
+    assert_eq!(converted, "foo-bar-100-baz-qux");
+}

--- a/tests/macro_case_test.rs
+++ b/tests/macro_case_test.rs
@@ -17,3 +17,11 @@ fn it_should_convert_to_macro_case_with_keep() {
     let converted = macro_case_with_keep("foo_bar100%BAZQux", "%");
     assert_eq!(converted, "FOO_BAR100%_BAZ_QUX");
 }
+
+#[test]
+fn it_should_convert_to_macro_case_with_nums_as_word() {
+    use stringcase::macro_case_with_nums_as_word as macro_case;
+
+    let converted = macro_case("foo-bar100%-baz-qux");
+    assert_eq!(converted, "FOO_BAR_100_BAZ_QUX");
+}

--- a/tests/snake_case_test.rs
+++ b/tests/snake_case_test.rs
@@ -17,3 +17,11 @@ fn it_should_convert_to_snake_case_with_keep() {
     let converted = snake_case_with_keep("foo_bar100%BAZQux", "%");
     assert_eq!(converted, "foo_bar100%_baz_qux");
 }
+
+#[test]
+fn it_should_convert_to_snake_case_with_nums_as_word() {
+    use stringcase::snake_case_with_nums_as_word as snake_case;
+
+    let converted = snake_case("foo-bar100%-baz-qux");
+    assert_eq!(converted, "foo_bar_100_baz_qux");
+}

--- a/tests/train_case_test.rs
+++ b/tests/train_case_test.rs
@@ -17,3 +17,11 @@ fn it_should_convert_to_train_case_with_keep() {
     let converted = train_case_with_keep("foo_bar100%BAZQux", "%");
     assert_eq!(converted, "Foo-Bar100%-Baz-Qux");
 }
+
+#[test]
+fn it_should_convert_to_train_case_with_nums_as_word() {
+    use stringcase::train_case_with_nums_as_word as train_case;
+
+    let converted = train_case("foo-bar100%-baz-qux");
+    assert_eq!(converted, "Foo-Bar-100-Baz-Qux");
+}


### PR DESCRIPTION
This PR is for resolving #18.

In this PR, the new five functions are added for converting a string into each case with inserting separators before number sequences.

- `cobol_case_with_nums_as_word`
- `kebab_case_with_nums_as_word`
- `macro_case_with_nums_as_word`
- `snake_case_with_nums_as_word`
- `train_case_with_nums_as_word`

These functions can be used as follows:

```rust
use stringcase::snake_case_with_nums_as_word as snake_case;
snake_case("valueOf1");  // ==> "value-of-1"
```

In addition, this PR adds the new five methods of `Caser` corresponding to each function above.

- `Caser#cobol_case_with_nums_as_word`
- `Caser#kebab_case_with_nums_as_word`
- `Caser#macro_case_with_nums_as_word`
- `Caser#snake_case_with_nums_as_word`
- `Caser#train_case_with_nums_as_word`

These methods can be used as follows:

```rust
use stringcase::Caser;
"valueOf1".to_snake_case_with_nums_as_word();  // ==> "value-of-1"
```
