### PR TITLE
new!: added cobol_case_with_options and made use it in existing cobol case functions

### DIFF
--- a/src/caser.rs
+++ b/src/caser.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Takayuki Sato. All Rights Reserved.
+// Copyright (C) 2024-2025 Takayuki Sato. All Rights Reserved.
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
@@ -62,64 +62,55 @@ pub trait Caser<T: AsRef<str>> {
 
     // cobol case
 
-    /// Converts a string to cobol case.
+    /// Converts the input string to cobol case.
     ///
-    /// This method targets the upper and lower cases of ASCII alphabets for
-    /// capitalization, and all characters except ASCII alphabets and ASCII
-    /// numbers are replaced to hyphens as word separators.
+    /// It treats the end of a sequence of non-alphabetical characters as a word boundary,
+    /// but not the beginning.
     ///
     /// ```rust
     ///     use stringcase::Caser;
     ///
-    ///     let cobol = "fooBar100Baz".to_cobol_case();
-    ///     assert_eq!(cobol, "FOO-BAR100-BAZ");
+    ///     let cobol = "foo_bar_baz".to_cobol_case();
+    ///     assert_eq!(cobol, "FOO-BAR-BAZ");
     /// ```
     fn to_cobol_case(&self) -> String;
 
-    /// Converts a string to cobol case.
-    ///
-    /// This method targets the upper and lower cases of ASCII alphabets and
-    /// ASCII numbers for capitalization, and all characters except ASCII
-    /// alphabets and ASCII numbers are replaced to hyphens as word separators.
+    /// Converts the input string to cobol case with the specified options.
     ///
     /// ```rust
-    ///     use stringcase::Caser;
-    ///
-    ///     let cobol = "fooBar100Baz".to_cobol_case_with_nums_as_word();
+    ///     let opts = stringcase::Options{
+    ///       separate_before_non_alphabets: true,
+    ///       separate_after_non_alphabets: true,
+    ///       separators: "",
+    ///       keep: "",
+    ///     };
+    ///     let cobol = stringcase::cobol_case_with_options("foo_bar_100_baz", &opts);
     ///     assert_eq!(cobol, "FOO-BAR-100-BAZ");
     /// ```
+    fn to_cobol_case_with_options(&self, opts: &Options) -> String;
+
+    /// Converts the input string to cobol case.
+    ///
+    /// It treats the begin and the end of a sequence of non-alphabetical characters as a word
+    /// boundary.
+    #[deprecated(
+        since = "0.4.0",
+        note = "Should use to_cobol_case_with_options instead"
+    )]
     fn to_cobol_case_with_nums_as_word(&self) -> String;
 
-    /// Converts a string to cobol case using the specified characters as
-    /// separators.
-    ///
-    /// This method targets only the upper and lower cases of ASCII alphabets
-    /// for capitalization, and the characters specified as the second argument
-    /// of this method are regarded as word separators and are replaced to
-    /// hyphens.
-    ///
-    /// ```rust
-    ///     use stringcase::Caser;
-    ///
-    ///     let cobol = "foo-bar100%baz".to_cobol_case_with_sep("- ");
-    ///     assert_eq!(cobol, "FOO-BAR100%-BAZ");
-    /// ```
+    /// Converts the input string to cobol case with the specified separator characters.
+    #[deprecated(
+        since = "0.4.0",
+        note = "Should use to_cobol_case_with_options instead"
+    )]
     fn to_cobol_case_with_sep(&self, seps: &str) -> String;
 
-    /// Converts a string to cobol case using characters other than the
-    /// specified characters as separators.
-    ///
-    /// This method targets only the upper and lower cases of ASCII alphabets
-    /// for capitalization, and the characters other than the specified
-    /// characters as the second argument of this method are regarded as word
-    /// separators and are replaced to hyphens.
-    ///
-    /// ```rust
-    ///     use stringcase::Caser;
-    ///
-    ///     let cobol = "foo-bar100%baz".to_cobol_case_with_keep("%");
-    ///     assert_eq!(cobol, "FOO-BAR100%-BAZ");
-    /// ```
+    /// Converts the input string to cobol case with the specified characters to be kept.
+    #[deprecated(
+        since = "0.4.0",
+        note = "Should use to_cobol_case_with_options instead"
+    )]
     fn to_cobol_case_with_keep(&self, keeped: &str) -> String;
 
     // kebab case
@@ -418,7 +409,13 @@ impl<T: AsRef<str>> Caser<T> for T {
     // camel case
 
     fn to_camel_case(&self) -> String {
-        camel_case(&self.as_ref())
+        let opts = Options {
+            separate_before_non_alphabets: false,
+            separate_after_non_alphabets: true,
+            separators: "",
+            keep: "",
+        };
+        camel_case_with_options(&self.as_ref(), &opts)
     }
 
     fn to_camel_case_with_options(&self, opts: &Options) -> String {
@@ -448,19 +445,47 @@ impl<T: AsRef<str>> Caser<T> for T {
     // cobol case
 
     fn to_cobol_case(&self) -> String {
-        cobol_case(&self.as_ref())
+        let opts = Options {
+            separate_before_non_alphabets: false,
+            separate_after_non_alphabets: true,
+            separators: "",
+            keep: "",
+        };
+        cobol_case_with_options(&self.as_ref(), &opts)
+    }
+
+    fn to_cobol_case_with_options(&self, opts: &Options) -> String {
+        cobol_case_with_options(&self.as_ref(), opts)
     }
 
     fn to_cobol_case_with_nums_as_word(&self) -> String {
-        cobol_case_with_nums_as_word(&self.as_ref())
+        let opts = Options {
+            separate_before_non_alphabets: true,
+            separate_after_non_alphabets: true,
+            separators: "",
+            keep: "",
+        };
+        cobol_case_with_options(&self.as_ref(), &opts)
     }
 
     fn to_cobol_case_with_sep(&self, seps: &str) -> String {
-        cobol_case_with_sep(&self.as_ref(), seps)
+        let opts = Options {
+            separate_before_non_alphabets: false,
+            separate_after_non_alphabets: true,
+            separators: seps,
+            keep: "",
+        };
+        cobol_case_with_options(&self.as_ref(), &opts)
     }
 
-    fn to_cobol_case_with_keep(&self, keeped: &str) -> String {
-        cobol_case_with_keep(&self.as_ref(), keeped)
+    fn to_cobol_case_with_keep(&self, kept: &str) -> String {
+        let opts = Options {
+            separate_before_non_alphabets: false,
+            separate_after_non_alphabets: true,
+            separators: "",
+            keep: kept,
+        };
+        cobol_case_with_options(&self.as_ref(), &opts)
     }
 
     // kebab case
@@ -614,31 +639,52 @@ mod tests_of_caser {
 
     #[test]
     fn it_should_convert_to_cobol_case_with_nums_as_word() {
-        let result = "foo_bar100%BAZQux".to_cobol_case_with_nums_as_word();
+        let opts = Options {
+            separate_before_non_alphabets: true,
+            separate_after_non_alphabets: true,
+            separators: "",
+            keep: "",
+        };
+
+        let result = "foo_bar100%BAZQux".to_cobol_case_with_options(&opts);
         assert_eq!(result, "FOO-BAR-100-BAZ-QUX");
 
         let string = String::from("foo_bar100%BAZQux");
-        let result = string.to_cobol_case_with_nums_as_word();
+        let result = string.to_cobol_case_with_options(&opts);
         assert_eq!(result, "FOO-BAR-100-BAZ-QUX");
     }
 
     #[test]
     fn it_should_convert_to_cobol_case_with_sep() {
-        let result = "foo_bar100%BAZQux".to_cobol_case_with_sep("_");
+        let opts = Options {
+            separate_before_non_alphabets: false,
+            separate_after_non_alphabets: true,
+            separators: "_",
+            keep: "",
+        };
+
+        let result = "foo_bar100%BAZQux".to_cobol_case_with_options(&opts);
         assert_eq!(result, "FOO-BAR100%-BAZ-QUX");
 
         let string = String::from("foo_bar100%BAZQux");
-        let result = string.to_cobol_case_with_sep("_");
+        let result = string.to_cobol_case_with_options(&opts);
         assert_eq!(result, "FOO-BAR100%-BAZ-QUX");
     }
 
     #[test]
     fn it_should_convert_to_cobol_case_with_keep() {
-        let result = "foo_bar100%BAZQux".to_cobol_case_with_keep("%");
+        let opts = Options {
+            separate_before_non_alphabets: false,
+            separate_after_non_alphabets: true,
+            separators: "",
+            keep: "%",
+        };
+
+        let result = "foo_bar100%BAZQux".to_cobol_case_with_options(&opts);
         assert_eq!(result, "FOO-BAR100%-BAZ-QUX");
 
         let string = String::from("foo_bar100%BAZQux");
-        let result = string.to_cobol_case_with_keep("%");
+        let result = string.to_cobol_case_with_options(&opts);
         assert_eq!(result, "FOO-BAR100%-BAZ-QUX");
     }
 

--- a/src/cobol_case.rs
+++ b/src/cobol_case.rs
@@ -1,321 +1,167 @@
-// Copyright (C) 2024 Takayuki Sato. All Rights Reserved.
+// Copyright (C) 2024-2025 Takayuki Sato. All Rights Reserved.
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
-/// Converts a string to cobol case.
+use crate::options::Options;
+
+/// Converts the input string to cobol case with the specified options.
 ///
-/// This function takes a string slice as its argument, then returns a `String`
-/// of which the case style is cobol case.
+/// ```rust
+///     let opts = stringcase::Options{
+///       separate_before_non_alphabets: true,
+///       separate_after_non_alphabets: true,
+///       separators: "",
+///       keep: "",
+///     };
+///     let cobol = stringcase::cobol_case_with_options("fooBar123Baz", &opts);
+///     assert_eq!(cobol, "FOO-BAR-123-BAZ");
+/// ```
+pub fn cobol_case_with_options(input: &str, opts: &Options) -> String {
+    let mut result = String::with_capacity(input.len() + input.len() / 2);
+    // .len returns byte count but ok in this case!
+
+    #[derive(PartialEq)]
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfSepMark,
+        NextOfKeptMark,
+        Other,
+    }
+
+    let mut flag = ChIs::FirstOfStr;
+
+    for ch in input.chars() {
+        if ch.is_ascii_uppercase() {
+            if flag == ChIs::FirstOfStr {
+                result.push(ch);
+                flag = ChIs::NextOfUpper;
+            } else if flag == ChIs::NextOfUpper
+                || flag == ChIs::NextOfContdUpper
+                || (!opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
+            {
+                result.push(ch);
+                flag = ChIs::NextOfContdUpper;
+            } else {
+                result.push('-');
+                result.push(ch);
+                flag = ChIs::NextOfUpper;
+            }
+        } else if ch.is_ascii_lowercase() {
+            if flag == ChIs::NextOfContdUpper {
+                if let Some(prev) = result.pop() {
+                    result.push('-');
+                    result.push(prev);
+                    result.push(ch.to_ascii_uppercase());
+                }
+            } else if flag == ChIs::NextOfSepMark
+                || (opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
+            {
+                result.push('-');
+                result.push(ch.to_ascii_uppercase());
+            } else {
+                result.push(ch.to_ascii_uppercase());
+            }
+            flag = ChIs::Other;
+        } else {
+            let mut is_kept_char = false;
+            if ch.is_ascii_digit() {
+                is_kept_char = true;
+            } else if !opts.separators.is_empty() {
+                if !opts.separators.contains(ch) {
+                    is_kept_char = true;
+                }
+            } else if !opts.keep.is_empty() {
+                if opts.keep.contains(ch) {
+                    is_kept_char = true;
+                }
+            }
+
+            if is_kept_char {
+                if opts.separate_before_non_alphabets {
+                    if flag == ChIs::FirstOfStr || flag == ChIs::NextOfKeptMark {
+                        result.push(ch);
+                    } else {
+                        result.push('-');
+                        result.push(ch);
+                    }
+                } else {
+                    if flag != ChIs::NextOfSepMark {
+                        result.push(ch);
+                    } else {
+                        result.push('-');
+                        result.push(ch);
+                    }
+                }
+                flag = ChIs::NextOfKeptMark;
+            } else {
+                if flag != ChIs::FirstOfStr {
+                    flag = ChIs::NextOfSepMark;
+                }
+            }
+        }
+    }
+
+    result
+}
+
+/// Converts the input string to cobol case.
 ///
-/// This function targets the upper and lower cases of ASCII alphabets for
-/// capitalization, and all characters except ASCII alphabets and ASCII numbers
-/// are replaced to hyphens as word separators.
+/// It treats the end of a sequence of non-alphabetical characters as a word boundary, but not
+/// the beginning.
 ///
 /// ```rust
 ///     let cobol = stringcase::cobol_case("fooBar123Baz");
 ///     assert_eq!(cobol, "FOO-BAR123-BAZ");
 /// ```
 pub fn cobol_case(input: &str) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
-
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeepedMark,
-        Others,
-    }
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if ch.is_ascii_uppercase() {
-            match flag {
-                ChIs::FirstOfStr => {
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
-                    result.push(ch);
-                    flag = ChIs::NextOfContdUpper;
-                }
-                _ => {
-                    result.push('-');
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-            }
-        } else if ch.is_ascii_lowercase() {
-            match flag {
-                ChIs::NextOfContdUpper => match result.pop() {
-                    Some(prev) => {
-                        result.push('-');
-                        result.push(prev);
-                    }
-                    None => (), // impossible
-                },
-                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
-                    result.push('-');
-                }
-                _ => (),
-            }
-            result.push(ch.to_ascii_uppercase());
-            flag = ChIs::Others;
-        } else if ch.is_ascii_digit() {
-            match flag {
-                ChIs::NextOfSepMark => result.push('-'),
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::NextOfKeepedMark;
-        } else {
-            match flag {
-                ChIs::FirstOfStr => (),
-                _ => flag = ChIs::NextOfSepMark,
-            }
-        }
-    }
-
-    result
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "",
+    };
+    cobol_case_with_options(input, &opts)
 }
 
-/// Converts a string to cobol case.
-///
-/// This function takes a string slice as its argument, then returns a `String`
-/// of which the case style is cobol case.
-///
-/// This function targets the upper and lower cases of ASCII alphabets and ASCII numbers
-/// for capitalization, and all characters except ASCII alphabets and ASCII numbers
-/// are replaced to hyphens as word separators.
-///
-/// ```rust
-///     let cobol = stringcase::cobol_case_with_nums_as_word("fooBar123Baz");
-///     assert_eq!(cobol, "FOO-BAR-123-BAZ");
-/// ```
-pub fn cobol_case_with_nums_as_word(input: &str) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
-
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeepedMark, // = next of number
-        Others,
-    }
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if ch.is_ascii_uppercase() {
-            match flag {
-                ChIs::FirstOfStr => {
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
-                    result.push(ch);
-                    flag = ChIs::NextOfContdUpper;
-                }
-                _ => {
-                    result.push('-');
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-            }
-        } else if ch.is_ascii_lowercase() {
-            match flag {
-                ChIs::NextOfContdUpper => match result.pop() {
-                    Some(prev) => {
-                        result.push('-');
-                        result.push(prev);
-                    }
-                    None => (), // impossible
-                },
-                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
-                    result.push('-');
-                }
-                _ => (),
-            }
-            result.push(ch.to_ascii_uppercase());
-            flag = ChIs::Others;
-        } else if ch.is_ascii_digit() {
-            match flag {
-                ChIs::FirstOfStr => (),
-                ChIs::NextOfKeepedMark => (),
-                _ => result.push('-'),
-            }
-            result.push(ch);
-            flag = ChIs::NextOfKeepedMark;
-        } else {
-            match flag {
-                ChIs::FirstOfStr => (),
-                _ => flag = ChIs::NextOfSepMark,
-            }
-        }
-    }
-
-    result
-}
-
-/// Converts a string to cobol case using the specified characters as
-/// separators.
-///
-/// This function takes a string slice as its argument, then returns a `String`
-/// of which the case style is cobol case.
-///
-/// This function targets only the upper and lower cases of ASCII alphabets for
-/// capitalization, and the characters specified as the second argument of this
-/// function are regarded as word separators and are replaced to hyphens.
-///
-/// ```rust
-///     let cobol = stringcase::cobol_case_with_sep("foo-bar100%baz", "- ");
-///     assert_eq!(cobol, "FOO-BAR100%-BAZ");
-/// ```
+/// Converts the input string to cobol case with the specified separator characters.
+#[deprecated(since = "0.4.0", note = "Should use cobol_case_with_options instead")]
 pub fn cobol_case_with_sep(input: &str, seps: &str) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
-
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeepedMark,
-        Others,
-    }
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if seps.contains(ch) {
-            match flag {
-                ChIs::FirstOfStr => (),
-                _ => flag = ChIs::NextOfSepMark,
-            }
-        } else if ch.is_ascii_uppercase() {
-            match flag {
-                ChIs::FirstOfStr => {
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
-                    result.push(ch);
-                    flag = ChIs::NextOfContdUpper;
-                }
-                _ => {
-                    result.push('-');
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-            }
-        } else if ch.is_ascii_lowercase() {
-            match flag {
-                ChIs::NextOfContdUpper => match result.pop() {
-                    Some(prev) => {
-                        result.push('-');
-                        result.push(prev);
-                    }
-                    None => (), // impossible
-                },
-                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
-                    result.push('-');
-                }
-                _ => (),
-            }
-            result.push(ch.to_ascii_uppercase());
-            flag = ChIs::Others;
-        } else {
-            match flag {
-                ChIs::NextOfSepMark => result.push('-'),
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::NextOfKeepedMark;
-        }
-    }
-
-    result
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: seps,
+        keep: "",
+    };
+    cobol_case_with_options(input, &opts)
 }
 
-/// Converts a string to cobol case using characters other than the specified
-/// characters as separators.
-///
-/// This function takes a string slice as its argument, then returns a `String`
-/// of which the case style is cobol case.
-///
-/// This function targets only the upper and lower cases of ASCII alphabets for
-/// capitalization, and the characters other than the specified characters as
-/// the second argument of this function are regarded as word separators and
-/// are replaced to hyphens.
-///
-/// ```rust
-///     let cobol = stringcase::cobol_case_with_keep("foo-bar100%baz", "%");
-///     assert_eq!(cobol, "FOO-BAR100%-BAZ");
-/// ```
-pub fn cobol_case_with_keep(input: &str, keeped: &str) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
+/// Converts the input string to cobol case with the specified characters to be kept.
+#[deprecated(since = "0.4.0", note = "Should use cobol_case_with_options instead")]
+pub fn cobol_case_with_keep(input: &str, kept: &str) -> String {
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: kept,
+    };
+    cobol_case_with_options(input, &opts)
+}
 
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeepedMark,
-        Others,
-    }
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if ch.is_ascii_uppercase() {
-            match flag {
-                ChIs::FirstOfStr => {
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
-                    result.push(ch);
-                    flag = ChIs::NextOfContdUpper;
-                }
-                _ => {
-                    result.push('-');
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-            }
-        } else if ch.is_ascii_lowercase() {
-            match flag {
-                ChIs::NextOfContdUpper => match result.pop() {
-                    Some(prev) => {
-                        result.push('-');
-                        result.push(prev);
-                    }
-                    None => (), // impossible
-                },
-                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
-                    result.push('-');
-                }
-                _ => (),
-            }
-            result.push(ch.to_ascii_uppercase());
-            flag = ChIs::Others;
-        } else if ch.is_ascii_digit() || keeped.contains(ch) {
-            match flag {
-                ChIs::NextOfSepMark => result.push('-'),
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::NextOfKeepedMark;
-        } else {
-            match flag {
-                ChIs::FirstOfStr => (),
-                _ => flag = ChIs::NextOfSepMark,
-            }
-        }
-    }
-
-    result
+/// Converts the input string to cobol case.
+///
+/// It treats the beginning and the end of a sequence of non-alphabetical characters as a word
+/// boundary.
+#[deprecated(since = "0.4.0", note = "Should use cobol_case_with_options instead")]
+pub fn cobol_case_with_nums_as_word(input: &str) -> String {
+    let opts = Options {
+        separate_before_non_alphabets: true,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "",
+    };
+    cobol_case_with_options(input, &opts)
 }
 
 #[cfg(test)]
@@ -323,383 +169,1966 @@ mod tests_of_cobol_case {
     use super::*;
 
     #[test]
-    fn it_should_convert_camel_case() {
-        let result = cobol_case("abcDefGHIjk");
-        assert_eq!(result, "ABC-DEF-GH-IJK");
+    fn convert_camel_case() {
+        assert_eq!(cobol_case("abcDefGHIjk"), "ABC-DEF-GH-IJK");
     }
 
     #[test]
-    fn it_should_convert_pascal_case() {
-        let result = cobol_case("AbcDefGHIjk");
-        assert_eq!(result, "ABC-DEF-GH-IJK");
+    fn convert_pascal_case() {
+        assert_eq!(cobol_case("AbcDefGHIjk"), "ABC-DEF-GH-IJK");
     }
 
     #[test]
-    fn it_should_convert_snake_case() {
-        let result = cobol_case("abc_def_ghi");
-        assert_eq!(result, "ABC-DEF-GHI");
+    fn convert_snake_case() {
+        assert_eq!(cobol_case("abc_def_ghi"), "ABC-DEF-GHI");
     }
 
     #[test]
-    fn it_should_convert_kebab_case() {
-        let result = cobol_case("abc-def-ghi");
-        assert_eq!(result, "ABC-DEF-GHI");
+    fn convert_kebab_case() {
+        assert_eq!(cobol_case("abc-def-ghi"), "ABC-DEF-GHI");
     }
 
     #[test]
-    fn it_should_convert_train_case() {
-        let result = cobol_case("Abc-Def-Ghi");
-        assert_eq!(result, "ABC-DEF-GHI");
+    fn convert_train_case() {
+        assert_eq!(cobol_case("Abc-Def-Ghi"), "ABC-DEF-GHI");
     }
 
     #[test]
-    fn it_should_convert_macro_case() {
-        let result = cobol_case("ABC_DEF_GHI");
-        assert_eq!(result, "ABC-DEF-GHI");
+    fn convert_macro_case() {
+        assert_eq!(cobol_case("ABC_DEF_GHI"), "ABC-DEF-GHI");
     }
 
     #[test]
-    fn it_should_convert_cobol_case() {
-        let result = cobol_case("ABC-DEF-GHI");
-        assert_eq!(result, "ABC-DEF-GHI");
+    fn convert_cobol_case() {
+        assert_eq!(cobol_case("ABC-DEF-GHI"), "ABC-DEF-GHI");
     }
 
     #[test]
-    fn it_should_keep_digits() {
-        let result = cobol_case("abc123-456defG789HIJklMN12");
-        assert_eq!(result, "ABC123-456-DEF-G789-HI-JKL-MN12");
+    fn convert_with_digits() {
+        assert_eq!(
+            cobol_case("abc123-456defG89HIJklMN12"),
+            "ABC123-456-DEF-G89-HI-JKL-MN12",
+        );
     }
 
     #[test]
-    fn it_should_convert_when_starting_with_digit() {
-        let result = cobol_case("123abc456def");
-        assert_eq!(result, "123-ABC456-DEF");
-
-        let result = cobol_case("123ABC456DEF");
-        assert_eq!(result, "123-ABC456-DEF");
+    fn convert_with_symbols_as_separators() {
+        assert_eq!(
+            cobol_case(":.abc~!@def#$ghi%&jk(lm)no/?"),
+            "ABC-DEF-GHI-JK-LM-NO",
+        );
     }
 
     #[test]
-    fn it_should_treat_marks_as_separators() {
-        let result = cobol_case(":.abc~!@def#$ghi%&jk(lm)no/?");
-        assert_eq!(result, "ABC-DEF-GHI-JK-LM-NO");
+    fn convert_starting_with_digit() {
+        assert_eq!(cobol_case("123abc456def"), "123-ABC456-DEF");
+        assert_eq!(cobol_case("123ABC456DEF"), "123-ABC456-DEF");
+        assert_eq!(cobol_case("123Abc456Def"), "123-ABC456-DEF");
     }
 
     #[test]
-    fn it_should_convert_empty() {
-        let result = cobol_case("");
-        assert_eq!(result, "");
-    }
-
-    #[test]
-    fn it_should_treat_number_sequence_by_default() {
-        let result = cobol_case("abc123Def456#Ghi789");
-        assert_eq!(result, "ABC123-DEF456-GHI789");
-
-        let result = cobol_case("ABC123-DEF456#GHI789");
-        assert_eq!(result, "ABC123-DEF456-GHI789");
-
-        let result = cobol_case("abc123-def456#ghi789");
-        assert_eq!(result, "ABC123-DEF456-GHI789");
-
-        let result = cobol_case("ABC123_DEF456#GHI789");
-        assert_eq!(result, "ABC123-DEF456-GHI789");
-
-        let result = cobol_case("Abc123Def456#Ghi789");
-        assert_eq!(result, "ABC123-DEF456-GHI789");
-
-        let result = cobol_case("abc123_def456#ghi789");
-        assert_eq!(result, "ABC123-DEF456-GHI789");
-
-        let result = cobol_case("Abc123-Def456#-Ghi789");
-        assert_eq!(result, "ABC123-DEF456-GHI789");
-
-        let result = cobol_case("000-abc123_def456#ghi789");
-        assert_eq!(result, "000-ABC123-DEF456-GHI789");
+    fn convert_empty_string() {
+        assert_eq!(cobol_case(""), "");
     }
 }
 
 #[cfg(test)]
-mod tests_of_cobol_case_with_nums_as_word {
+mod tests_of_cobol_case_with_options {
     use super::*;
 
-    #[test]
-    fn it_should_convert_camel_case() {
-        let result = cobol_case_with_nums_as_word("abcDefGHIjk");
-        assert_eq!(result, "ABC-DEF-GH-IJK");
+    mod non_alphabets_as_head_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC-123-456DEF-G-89HI-JKL-MN-12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "ABC-DEF-GHI-JK-LM-NO");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123ABC-456DEF");
+
+            let result = cobol_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123ABC-456DEF");
+
+            let result = cobol_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123-ABC-456-DEF");
+        }
+
+        #[test]
+        fn convert_an_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_pascal_case() {
-        let result = cobol_case_with_nums_as_word("AbcDefGHIjk");
-        assert_eq!(result, "ABC-DEF-GH-IJK");
+    mod non_alphabets_as_tail_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123-456-DEF-G89-HI-JKL-MN12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "ABC-DEF-GHI-JK-LM-NO");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123-ABC456-DEF");
+
+            let result = cobol_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123-ABC456-DEF");
+
+            let result = cobol_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123-ABC456-DEF");
+        }
+
+        #[test]
+        fn convert_an_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_snake_case() {
-        let result = cobol_case_with_nums_as_word("abc_def_ghi");
-        assert_eq!(result, "ABC-DEF-GHI");
+    mod non_alphabets_as_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC-123-456-DEF-G-89-HI-JKL-MN-12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "ABC-DEF-GHI-JK-LM-NO");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123-ABC-456-DEF");
+
+            let result = cobol_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123-ABC-456-DEF");
+
+            let result = cobol_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123-ABC-456-DEF");
+        }
+
+        #[test]
+        fn convert_an_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_kebab_case() {
-        let result = cobol_case_with_nums_as_word("abc-def-ghi");
-        assert_eq!(result, "ABC-DEF-GHI");
+    mod non_alphabets_as_part_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123-456DEF-G89HI-JKL-MN12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "ABC-DEF-GHI-JK-LM-NO");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123ABC456DEF");
+
+            let result = cobol_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123ABC456DEF");
+
+            let result = cobol_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123-ABC456-DEF");
+        }
+
+        #[test]
+        fn convert_an_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = cobol_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_train_case() {
-        let result = cobol_case_with_nums_as_word("Abc-Def-Ghi");
-        assert_eq!(result, "ABC-DEF-GHI");
+    mod non_alphabets_as_head_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "-";
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC-_DEF-_GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "_";
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC--DEF--GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "_";
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC---DEF---GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "-";
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC-_DEF-_GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "_";
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC--DEF--GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC-123-456DEF-G-89HI-JKL-MN-12");
+
+            opts.separators = "_";
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC-123-456DEF-G-89HI-JKL-MN-12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = cobol_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".ABC-~!-DEF-#-GHI-%-JK-LM-NO-?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123ABC-456DEF");
+
+            let result = cobol_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123ABC-456DEF");
+
+            let result = cobol_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123-ABC-456-DEF");
+        }
+
+        #[test]
+        fn convert_an_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_macro_case() {
-        let result = cobol_case_with_nums_as_word("ABC_DEF_GHI");
-        assert_eq!(result, "ABC-DEF-GHI");
+    mod non_alphabets_as_tail_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "-";
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_-DEF_-GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "_";
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC--DEF--GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "_";
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC--DEF--GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "-";
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_-DEF_-GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "_";
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC--DEF--GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123-456-DEF-G89-HI-JKL-MN12");
+
+            opts.separators = "_";
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123-456-DEF-G89-HI-JKL-MN12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = cobol_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".-ABC~!-DEF#-GHI%-JK-LM-NO-?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123-ABC456-DEF");
+
+            let result = cobol_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123-ABC456-DEF");
+
+            let result = cobol_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123-ABC456-DEF");
+        }
+
+        #[test]
+        fn convert_an_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_cobol_case() {
-        let result = cobol_case_with_nums_as_word("ABC-DEF-GHI");
-        assert_eq!(result, "ABC-DEF-GHI");
+    mod non_alphabets_as_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "-";
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC-_-DEF-_-GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "_";
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC---DEF---GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "_";
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC---DEF---GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "-";
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC-_-DEF-_-GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "_";
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC---DEF---GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC-123-456-DEF-G-89-HI-JKL-MN-12");
+
+            opts.separators = "_";
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC-123-456-DEF-G-89-HI-JKL-MN-12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = cobol_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".-ABC-~!-DEF-#-GHI-%-JK-LM-NO-?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123-ABC-456-DEF");
+
+            let result = cobol_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123-ABC-456-DEF");
+
+            let result = cobol_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123-ABC-456-DEF");
+        }
+
+        #[test]
+        fn convert_an_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_keep_digits() {
-        let result = cobol_case_with_nums_as_word("abc123-456defG789HIJklMN12");
-        assert_eq!(result, "ABC-123-456-DEF-G-789-HI-JKL-MN-12");
+    mod non_alphabets_as_part_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "-";
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "_";
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "_";
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC--DEF--GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "-";
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.separators = "_";
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123-456DEF-G89HI-JKL-MN12");
+
+            opts.separators = "_";
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123-456DEF-G89HI-JKL-MN12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = cobol_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".ABC~!-DEF#-GHI%-JK-LM-NO-?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123ABC456DEF");
+
+            let result = cobol_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123ABC456DEF");
+
+            let result = cobol_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123-ABC456-DEF");
+        }
+
+        #[test]
+        fn convert_an_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = cobol_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_when_starting_with_digit() {
-        let result = cobol_case_with_nums_as_word("123abc456def");
-        assert_eq!(result, "123-ABC-456-DEF");
+    mod non_alphabets_as_head_of_a_word_with_kept_characters {
+        use super::*;
 
-        let result = cobol_case_with_nums_as_word("123ABC456DEF");
-        assert_eq!(result, "123-ABC-456-DEF");
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                keep: "-_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                keep: "-_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                keep: "_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC-_DEF-_GHI");
+
+            opts.keep = "-";
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                keep: "_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.keep = "-";
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC--DEF--GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                keep: "_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.keep = "-";
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC---DEF---GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                keep: "-",
+                separators: "",
+            };
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.keep = "_";
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC-_DEF-_GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                keep: "_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.keep = "-";
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC--DEF--GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                keep: "_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC-123-456DEF-G-89HI-JKL-MN-12");
+
+            opts.keep = "-";
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC-123-456DEF-G-89HI-JKL-MN-12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                keep: ".~!#%?",
+                separators: "",
+            };
+            let result = cobol_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".ABC-~!-DEF-#-GHI-%-JK-LM-NO-?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                keep: "-_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123ABC-456DEF");
+
+            let result = cobol_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123ABC-456DEF");
+
+            let result = cobol_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123-ABC-456-DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                keep: "-_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_treat_marks_as_separators() {
-        let result = cobol_case_with_nums_as_word(":.abc~!@def#$ghi%&jk(lm)no/?");
-        assert_eq!(result, "ABC-DEF-GHI-JK-LM-NO");
+    mod non_alphabets_as_tail_of_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                keep: "-_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                keep: "-_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                keep: "-",
+                separators: "",
+            };
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.keep = "_";
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_-DEF_-GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                keep: "_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.keep = "-";
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC--DEF--GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                keep: "_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.keep = "-";
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC--DEF--GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                keep: "-",
+                separators: "",
+            };
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.keep = "_";
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_-DEF_-GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                keep: "_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.keep = "-";
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC--DEF--GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                keep: "_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123-456-DEF-G89-HI-JKL-MN12");
+
+            opts.keep = "-";
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123-456-DEF-G89-HI-JKL-MN12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                keep: ".~!#%?",
+                separators: "",
+            };
+            let result = cobol_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".-ABC~!-DEF#-GHI%-JK-LM-NO-?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                keep: "-_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123-ABC456-DEF");
+
+            let result = cobol_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123-ABC456-DEF");
+
+            let result = cobol_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123-ABC456-DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                keep: "-_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_empty() {
-        let result = cobol_case_with_nums_as_word("");
-        assert_eq!(result, "");
+    mod non_alphabets_as_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                keep: "-_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                keep: "-_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                keep: "-",
+                separators: "",
+            };
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.keep = "_";
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC-_-DEF-_-GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                keep: "_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.keep = "-";
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC---DEF---GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                keep: "_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.keep = "-";
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC---DEF---GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                keep: "-",
+                separators: "",
+            };
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.keep = "_";
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC-_-DEF-_-GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                keep: "_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+
+            opts.keep = "-";
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC---DEF---GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                keep: "_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC-123-456-DEF-G-89-HI-JKL-MN-12");
+
+            opts.keep = "-";
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC-123-456-DEF-G-89-HI-JKL-MN-12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                keep: ".~!#%?",
+                separators: "",
+            };
+            let result = cobol_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".-ABC-~!-DEF-#-GHI-%-JK-LM-NO-?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                keep: "-_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123-ABC-456-DEF");
+
+            let result = cobol_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123-ABC-456-DEF");
+
+            let result = cobol_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123-ABC-456-DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                keep: "-_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_treat_number_sequence_as_word() {
-        let result = cobol_case_with_nums_as_word("abc123Def456#Ghi789");
-        assert_eq!(result, "ABC-123-DEF-456-GHI-789");
+    mod non_alphabets_as_part_of_a_word_with_kept_characters {
+        use super::*;
 
-        let result = cobol_case_with_nums_as_word("ABC123-DEF456#GHI789");
-        assert_eq!(result, "ABC-123-DEF-456-GHI-789");
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                keep: "-_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
 
-        let result = cobol_case_with_nums_as_word("abc123-def456#ghi789");
-        assert_eq!(result, "ABC-123-DEF-456-GHI-789");
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                keep: "-_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC-DEF-GH-IJK");
+        }
 
-        let result = cobol_case_with_nums_as_word("ABC123_DEF456#GHI789");
-        assert_eq!(result, "ABC-123-DEF-456-GHI-789");
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                keep: "-",
+                separators: "",
+            };
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
 
-        let result = cobol_case_with_nums_as_word("Abc123Def456#Ghi789");
-        assert_eq!(result, "ABC-123-DEF-456-GHI-789");
+            opts.keep = "_";
+            let result = cobol_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
 
-        let result = cobol_case_with_nums_as_word("abc123_def456#ghi789");
-        assert_eq!(result, "ABC-123-DEF-456-GHI-789");
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                keep: "_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
 
-        let result = cobol_case_with_nums_as_word("Abc123-Def456#-Ghi789");
-        assert_eq!(result, "ABC-123-DEF-456-GHI-789");
+            opts.keep = "-";
+            let result = cobol_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
 
-        let result = cobol_case_with_nums_as_word("000-abc123_def456#ghi789");
-        assert_eq!(result, "000-ABC-123-DEF-456-GHI-789");
-    }
-}
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                keep: "_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
 
-#[cfg(test)]
-mod tests_of_cobol_case_with_sep {
-    use super::*;
+            opts.keep = "-";
+            let result = cobol_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC--DEF--GHI");
+        }
 
-    #[test]
-    fn it_should_convert_camel_case() {
-        let result = cobol_case_with_sep("abcDefGHIjk", "-_");
-        assert_eq!(result, "ABC-DEF-GH-IJK");
-    }
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                keep: "-",
+                separators: "",
+            };
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
 
-    #[test]
-    fn it_should_convert_pascal_case() {
-        let result = cobol_case_with_sep("AbcDefGHIjk", "-_");
-        assert_eq!(result, "ABC-DEF-GH-IJK");
-    }
+            opts.keep = "_";
+            let result = cobol_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
 
-    #[test]
-    fn it_should_convert_snake_case() {
-        let result = cobol_case_with_sep("abc_def_ghi", "_");
-        assert_eq!(result, "ABC-DEF-GHI");
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                keep: "_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
 
-        let result = cobol_case_with_sep("abc_def_ghi", "-");
-        assert_eq!(result, "ABC_-DEF_-GHI");
-    }
+            opts.keep = "-";
+            let result = cobol_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
 
-    #[test]
-    fn it_should_convert_kebab_case() {
-        let result = cobol_case_with_sep("abc-def-ghi", "-");
-        assert_eq!(result, "ABC-DEF-GHI");
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                keep: "_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123-456DEF-G89HI-JKL-MN12");
 
-        let result = cobol_case_with_sep("abc-def-ghi", "_");
-        assert_eq!(result, "ABC--DEF--GHI");
-    }
+            opts.keep = "-";
+            let result = cobol_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123-456DEF-G89HI-JKL-MN12");
+        }
 
-    #[test]
-    fn it_should_convert_train_case() {
-        let result = cobol_case_with_sep("Abc-Def-Ghi", "-");
-        assert_eq!(result, "ABC-DEF-GHI");
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                keep: ".~!#%?",
+                separators: "",
+            };
+            let result = cobol_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".ABC~!-DEF#-GHI%-JK-LM-NO-?");
+        }
 
-        let result = cobol_case_with_sep("Abc-Def-Ghi", "_");
-        assert_eq!(result, "ABC--DEF--GHI");
-    }
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                keep: "-_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123ABC456DEF");
 
-    #[test]
-    fn it_should_convert_macro_case() {
-        let result = cobol_case_with_sep("ABC_DEF_GHI", "_");
-        assert_eq!(result, "ABC-DEF-GHI");
+            let result = cobol_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123ABC456DEF");
 
-        let result = cobol_case_with_sep("ABC_DEF_GHI", "-");
-        assert_eq!(result, "ABC_-DEF_-GHI");
-    }
+            let result = cobol_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123-ABC456-DEF");
+        }
 
-    #[test]
-    fn it_should_convert_cobol_case() {
-        let result = cobol_case_with_sep("ABC-DEF-GHI", "-");
-        assert_eq!(result, "ABC-DEF-GHI");
-
-        let result = cobol_case_with_sep("ABC-DEF-GHI", "_");
-        assert_eq!(result, "ABC--DEF--GHI");
-    }
-
-    #[test]
-    fn it_should_keep_digits() {
-        let result = cobol_case_with_sep("abc123-456defG789HIJklMN12", "-");
-        assert_eq!(result, "ABC123-456-DEF-G789-HI-JKL-MN12");
-
-        let result = cobol_case_with_sep("abc123-456defG789HIJklMN12", "_");
-        assert_eq!(result, "ABC123-456-DEF-G789-HI-JKL-MN12");
-    }
-
-    #[test]
-    fn it_should_convert_when_starting_with_digit() {
-        let result = cobol_case_with_sep("123abc456def", "-");
-        assert_eq!(result, "123-ABC456-DEF");
-
-        let result = cobol_case_with_sep("123ABC456DEF", "-");
-        assert_eq!(result, "123-ABC456-DEF");
-    }
-
-    #[test]
-    fn it_should_treat_marks_as_separators() {
-        let result = cobol_case_with_sep(":.abc~!@def#$ghi%&jk(lm)no/?", ":@$&()/");
-        assert_eq!(result, ".-ABC~!-DEF#-GHI%-JK-LM-NO-?");
-    }
-
-    #[test]
-    fn it_should_convert_empty() {
-        let result = cobol_case_with_sep("", "_-");
-        assert_eq!(result, "");
-    }
-}
-
-#[cfg(test)]
-mod tests_of_cobol_case_with_keep {
-    use super::*;
-
-    #[test]
-    fn it_should_convert_camel_case() {
-        let result = cobol_case_with_keep("abcDefGHIjk", "-_");
-        assert_eq!(result, "ABC-DEF-GH-IJK");
-    }
-
-    #[test]
-    fn it_should_convert_pascal_case() {
-        let result = cobol_case_with_keep("AbcDefGHIjk", "-_");
-        assert_eq!(result, "ABC-DEF-GH-IJK");
-    }
-
-    #[test]
-    fn it_should_convert_snake_case() {
-        let result = cobol_case_with_keep("abc_def_ghi", "-");
-        assert_eq!(result, "ABC-DEF-GHI");
-
-        let result = cobol_case_with_keep("abc_def_ghi", "_");
-        assert_eq!(result, "ABC_-DEF_-GHI");
-    }
-
-    #[test]
-    fn it_should_convert_kebab_case() {
-        let result = cobol_case_with_keep("abc-def-ghi", "_");
-        assert_eq!(result, "ABC-DEF-GHI");
-
-        let result = cobol_case_with_keep("abc-def-ghi", "-");
-        assert_eq!(result, "ABC--DEF--GHI");
-    }
-
-    #[test]
-    fn it_should_convert_train_case() {
-        let result = cobol_case_with_keep("Abc-Def-Ghi", "_");
-        assert_eq!(result, "ABC-DEF-GHI");
-
-        let result = cobol_case_with_keep("Abc-Def-Ghi", "-");
-        assert_eq!(result, "ABC--DEF--GHI");
-    }
-
-    #[test]
-    fn it_should_convert_macro_case() {
-        let result = cobol_case_with_keep("ABC_DEF_GHI", "-");
-        assert_eq!(result, "ABC-DEF-GHI");
-
-        let result = cobol_case_with_keep("ABC_DEF_GHI", "_");
-        assert_eq!(result, "ABC_-DEF_-GHI");
-    }
-
-    #[test]
-    fn it_should_convert_cobol_case() {
-        let result = cobol_case_with_keep("ABC-DEF-GHI", "_");
-        assert_eq!(result, "ABC-DEF-GHI");
-
-        let result = cobol_case_with_keep("ABC-DEF-GHI", "-");
-        assert_eq!(result, "ABC--DEF--GHI");
-    }
-
-    #[test]
-    fn it_should_keep_digits() {
-        let result = cobol_case_with_keep("abc123-456defG789HIJklMN12", "_");
-        assert_eq!(result, "ABC123-456-DEF-G789-HI-JKL-MN12");
-
-        let result = cobol_case_with_keep("abc123-456defG789HIJklMN12", "-");
-        assert_eq!(result, "ABC123-456-DEF-G789-HI-JKL-MN12");
-    }
-
-    #[test]
-    fn it_should_convert_when_starting_with_digit() {
-        let result = cobol_case_with_keep("123abc456def", "-");
-        assert_eq!(result, "123-ABC456-DEF");
-
-        let result = cobol_case_with_keep("123ABC456DEF", "_");
-        assert_eq!(result, "123-ABC456-DEF");
-    }
-
-    #[test]
-    fn it_should_treat_marks_as_separators() {
-        let result = cobol_case_with_keep(":.abc~!@def#$ghi%&jk(lm)no/?", ".~!#%?");
-        assert_eq!(result, ".-ABC~!-DEF#-GHI%-JK-LM-NO-?");
-    }
-
-    #[test]
-    fn it_should_convert_empty() {
-        let result = cobol_case_with_sep("", "_-");
-        assert_eq!(result, "");
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                keep: "-_",
+                separators: "",
+            };
+            let result = cobol_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Takayuki Sato. All Rights Reserved.
+// Copyright (C) 2024-2025 Takayuki Sato. All Rights Reserved.
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 

--- a/tests/caser_test.rs
+++ b/tests/caser_test.rs
@@ -38,19 +38,37 @@ fn it_should_convert_to_cobol_case_by_method_of_string() {
 
 #[test]
 fn it_should_convert_to_cobol_case_with_nums_as_word_by_method_of_string() {
-    let converted = "foo_bar100BAZQux".to_cobol_case_with_nums_as_word();
+    let opts = Options {
+        separate_before_non_alphabets: true,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "",
+    };
+    let converted = "foo_bar100BAZQux".to_cobol_case_with_options(&opts);
     assert_eq!(converted, "FOO-BAR-100-BAZ-QUX");
 }
 
 #[test]
 fn it_should_convert_to_cobol_case_with_sep_by_method_of_string() {
-    let converted = "foo_bar100BAZQux".to_cobol_case_with_sep("_");
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "_",
+        keep: "",
+    };
+    let converted = "foo_bar100BAZQux".to_cobol_case_with_options(&opts);
     assert_eq!(converted, "FOO-BAR100-BAZ-QUX");
 }
 
 #[test]
 fn it_should_convert_to_cobol_case_with_keep_by_method_of_string() {
-    let converted = "foo_bar100BAZQux".to_cobol_case_with_keep("#");
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "#",
+    };
+    let converted = "foo_bar100BAZQux".to_cobol_case_with_options(&opts);
     assert_eq!(converted, "FOO-BAR100-BAZ-QUX");
 }
 

--- a/tests/cobol_case_test.rs
+++ b/tests/cobol_case_test.rs
@@ -1,4 +1,4 @@
-use stringcase::{cobol_case, cobol_case_with_keep, cobol_case_with_sep};
+use stringcase::{cobol_case, cobol_case_with_options, Options};
 
 #[test]
 fn it_should_convert_to_cobol_case() {
@@ -8,20 +8,36 @@ fn it_should_convert_to_cobol_case() {
 
 #[test]
 fn it_should_convert_to_cobol_case_with_sep() {
-    let converted = cobol_case_with_sep("foo_bar100%BAZQux", "_");
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "_",
+        keep: "",
+    };
+    let converted = cobol_case_with_options("foo_bar100%BAZQux", &opts);
     assert_eq!(converted, "FOO-BAR100%-BAZ-QUX");
 }
 
 #[test]
 fn it_should_convert_to_cobol_case_with_keep() {
-    let converted = cobol_case_with_keep("foo_bar100%BAZQux", "%");
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "%",
+    };
+    let converted = cobol_case_with_options("foo_bar100%BAZQux", &opts);
     assert_eq!(converted, "FOO-BAR100%-BAZ-QUX");
 }
 
 #[test]
 fn it_should_convert_to_cobol_case_with_nums_as_word() {
-    use stringcase::cobol_case_with_nums_as_word as cobol_case;
-
-    let converted = cobol_case("foo_bar100%BAZQux");
+    let opts = Options {
+        separate_before_non_alphabets: true,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "",
+    };
+    let converted = cobol_case_with_options("foo_bar100%BAZQux", &opts);
     assert_eq!(converted, "FOO-BAR-100-BAZ-QUX");
 }


### PR DESCRIPTION
(Related to #24)

This PR adds the new function `cobol_case_with_options`, which supports handling non alphabetical characters, separators, and kept characters with `Options`.

`cobol_case` is changed to use this function inside, and `cobol_case_with_nums_as_word`,  `cobol_case_with_sep` and `cobol_case_with_keep` are deprecated.