### PR TITLE
new!: added kebab_case_with_options and made use it in existing kebab case functions

### DIFF
--- a/src/caser.rs
+++ b/src/caser.rs
@@ -78,13 +78,15 @@ pub trait Caser<T: AsRef<str>> {
     /// Converts the input string to cobol case with the specified options.
     ///
     /// ```rust
+    ///     use stringcase::Caser;
+    ///
     ///     let opts = stringcase::Options{
     ///       separate_before_non_alphabets: true,
     ///       separate_after_non_alphabets: true,
     ///       separators: "",
     ///       keep: "",
     ///     };
-    ///     let cobol = stringcase::cobol_case_with_options("foo_bar_100_baz", &opts);
+    ///     let cobol = "foo_bar_100_baz".to_cobol_case_with_options(&opts);
     ///     assert_eq!(cobol, "FOO-BAR-100-BAZ");
     /// ```
     fn to_cobol_case_with_options(&self, opts: &Options) -> String;
@@ -115,63 +117,57 @@ pub trait Caser<T: AsRef<str>> {
 
     // kebab case
 
-    /// Converts a string to kebab case.
+    /// Converts the input string to kebab case.
     ///
-    /// This method targets the upper and lower cases of ASCII alphabets for
-    /// capitalization, and all characters except ASCII alphabets and ASCII numbers
-    /// are replaced to hyphens as word separators.
+    /// It treats the end of a sequence of non-alphabetical characters as a word boundary,
+    /// but not the beginning.
     ///
     /// ```rust
     ///     use stringcase::Caser;
     ///
-    ///     let kebab = "foo-bar100%baz".to_kebab_case();
-    ///     assert_eq!(kebab, "foo-bar100-baz");
+    ///     let kebab = "fooBarBaz".to_kebab_case();
+    ///     assert_eq!(kebab, "foo-bar-baz");
     /// ```
     fn to_kebab_case(&self) -> String;
 
-    /// Converts a string to kebab case.
-    ///
-    /// This method targets the upper and lower cases of ASCII alphabets and
-    /// ASCII numbers for capitalization, and all characters except ASCII
-    /// alphabets and ASCII numbers are replaced to hyphens as word separators.
+    /// Converts the input string to kebab case with the specified options.
     ///
     /// ```rust
     ///     use stringcase::Caser;
     ///
-    ///     let kebab = "foo-bar100%baz".to_kebab_case_with_nums_as_word();
+    ///     let opts = stringcase::Options{
+    ///       separate_before_non_alphabets: true,
+    ///       separate_after_non_alphabets: true,
+    ///       separators: "",
+    ///       keep: "",
+    ///     };
+    ///     let kebab = "foo_bar_100_baz".to_kebab_case_with_options(&opts);
     ///     assert_eq!(kebab, "foo-bar-100-baz");
     /// ```
+    fn to_kebab_case_with_options(&self, opts: &Options) -> String;
+
+    /// Converts the input string to kebab case.
+    ///
+    /// It treats the begin and the end of a sequence of non-alphabetical characters as a word
+    /// boundary.
+    #[deprecated(
+        since = "0.4.0",
+        note = "Should use to_kebab_case_with_options instead"
+    )]
     fn to_kebab_case_with_nums_as_word(&self) -> String;
 
-    /// Converts a string to kebab case using the specified characters as
-    /// separators.
-    ///
-    /// This method targets only the upper and lower cases of ASCII alphabets for
-    /// capitalization, and the characters specified as the second argument of this
-    /// method are regarded as word separators and are replaced to hyphens.
-    ///
-    /// ```rust
-    ///     use stringcase::Caser;
-    ///
-    ///     let kebab = "foo-bar100%baz".to_kebab_case_with_sep("- ");
-    ///     assert_eq!(kebab, "foo-bar100%-baz");
-    /// ```
+    /// Converts the input string to kebab case with the specified separator characters.
+    #[deprecated(
+        since = "0.4.0",
+        note = "Should use to_kebab_case_with_options instead"
+    )]
     fn to_kebab_case_with_sep(&self, seps: &str) -> String;
 
-    /// Converts a string to kebab case using characters other than the specified
-    /// characters as separators.
-    ///
-    /// This method targets only the upper and lower cases of ASCII alphabets for
-    /// capitalization, and the characters other than the specified characters as
-    /// the second argument of this method are regarded as word separators and are
-    /// replaced to hyphens.
-    ///
-    /// ```rust
-    ///     use stringcase::Caser;
-    ///
-    ///     let kebab = "foo-bar100%baz".to_kebab_case_with_keep("%");
-    ///     assert_eq!(kebab, "foo-bar100%-baz");
-    /// ```
+    /// Converts the input string to kebab case with the specified characters to be kept.
+    #[deprecated(
+        since = "0.4.0",
+        note = "Should use to_kebab_case_with_options instead"
+    )]
     fn to_kebab_case_with_keep(&self, keeped: &str) -> String;
 
     // macro case
@@ -491,19 +487,47 @@ impl<T: AsRef<str>> Caser<T> for T {
     // kebab case
 
     fn to_kebab_case(&self) -> String {
-        kebab_case(&self.as_ref())
+        let opts = Options {
+            separate_before_non_alphabets: false,
+            separate_after_non_alphabets: true,
+            separators: "",
+            keep: "",
+        };
+        kebab_case_with_options(&self.as_ref(), &opts)
+    }
+
+    fn to_kebab_case_with_options(&self, opts: &Options) -> String {
+        kebab_case_with_options(&self.as_ref(), opts)
     }
 
     fn to_kebab_case_with_nums_as_word(&self) -> String {
-        kebab_case_with_nums_as_word(&self.as_ref())
+        let opts = Options {
+            separate_before_non_alphabets: true,
+            separate_after_non_alphabets: true,
+            separators: "",
+            keep: "",
+        };
+        kebab_case_with_options(&self.as_ref(), &opts)
     }
 
     fn to_kebab_case_with_sep(&self, seps: &str) -> String {
-        kebab_case_with_sep(&self.as_ref(), seps)
+        let opts = Options {
+            separate_before_non_alphabets: false,
+            separate_after_non_alphabets: true,
+            separators: seps,
+            keep: "",
+        };
+        kebab_case_with_options(&self.as_ref(), &opts)
     }
 
-    fn to_kebab_case_with_keep(&self, keeped: &str) -> String {
-        kebab_case_with_keep(&self.as_ref(), keeped)
+    fn to_kebab_case_with_keep(&self, kept: &str) -> String {
+        let opts = Options {
+            separate_before_non_alphabets: false,
+            separate_after_non_alphabets: true,
+            separators: "",
+            keep: kept,
+        };
+        kebab_case_with_options(&self.as_ref(), &opts)
     }
 
     // macro case
@@ -702,31 +726,52 @@ mod tests_of_caser {
 
     #[test]
     fn it_should_convert_to_kebab_case_with_nums_as_word() {
-        let result = "foo_bar100%BAZQux".to_kebab_case_with_nums_as_word();
+        let opts = Options {
+            separate_before_non_alphabets: true,
+            separate_after_non_alphabets: true,
+            separators: "",
+            keep: "",
+        };
+
+        let result = "foo_bar100%BAZQux".to_kebab_case_with_options(&opts);
         assert_eq!(result, "foo-bar-100-baz-qux");
 
         let string = String::from("foo_bar100%BAZQux");
-        let result = string.to_kebab_case_with_nums_as_word();
+        let result = string.to_kebab_case_with_options(&opts);
         assert_eq!(result, "foo-bar-100-baz-qux");
     }
 
     #[test]
     fn it_should_convert_to_kebab_case_with_sep() {
-        let result = "foo_bar100%BAZQux".to_kebab_case_with_sep("_");
+        let opts = Options {
+            separate_before_non_alphabets: false,
+            separate_after_non_alphabets: true,
+            separators: "_",
+            keep: "",
+        };
+
+        let result = "foo_bar100%BAZQux".to_kebab_case_with_options(&opts);
         assert_eq!(result, "foo-bar100%-baz-qux");
 
         let string = String::from("foo_bar100%BAZQux");
-        let result = string.to_kebab_case_with_sep("_");
+        let result = string.to_kebab_case_with_options(&opts);
         assert_eq!(result, "foo-bar100%-baz-qux");
     }
 
     #[test]
     fn it_should_convert_to_kebab_case_with_keep() {
-        let result = "foo_bar100%BAZQux".to_kebab_case_with_keep("%");
+        let opts = Options {
+            separate_before_non_alphabets: false,
+            separate_after_non_alphabets: true,
+            separators: "",
+            keep: "%",
+        };
+
+        let result = "foo_bar100%BAZQux".to_kebab_case_with_options(&opts);
         assert_eq!(result, "foo-bar100%-baz-qux");
 
         let string = String::from("foo_bar100%BAZQux");
-        let result = string.to_kebab_case_with_keep("%");
+        let result = string.to_kebab_case_with_options(&opts);
         assert_eq!(result, "foo-bar100%-baz-qux");
     }
 

--- a/src/caser.rs
+++ b/src/caser.rs
@@ -58,7 +58,7 @@ pub trait Caser<T: AsRef<str>> {
         since = "0.4.0",
         note = "Should use to_camel_case_with_options instead"
     )]
-    fn to_camel_case_with_keep(&self, keeped: &str) -> String;
+    fn to_camel_case_with_keep(&self, kept: &str) -> String;
 
     // cobol case
 
@@ -113,7 +113,7 @@ pub trait Caser<T: AsRef<str>> {
         since = "0.4.0",
         note = "Should use to_cobol_case_with_options instead"
     )]
-    fn to_cobol_case_with_keep(&self, keeped: &str) -> String;
+    fn to_cobol_case_with_keep(&self, kept: &str) -> String;
 
     // kebab case
 
@@ -168,7 +168,7 @@ pub trait Caser<T: AsRef<str>> {
         since = "0.4.0",
         note = "Should use to_kebab_case_with_options instead"
     )]
-    fn to_kebab_case_with_keep(&self, keeped: &str) -> String;
+    fn to_kebab_case_with_keep(&self, kept: &str) -> String;
 
     // macro case
 
@@ -229,7 +229,7 @@ pub trait Caser<T: AsRef<str>> {
     ///     let macro_ = "foo-bar100%baz".to_macro_case_with_keep("%");
     ///     assert_eq!(macro_, "FOO_BAR100%_BAZ");
     /// ```
-    fn to_macro_case_with_keep(&self, keeped: &str) -> String;
+    fn to_macro_case_with_keep(&self, kept: &str) -> String;
 
     // pascal case
 
@@ -276,7 +276,7 @@ pub trait Caser<T: AsRef<str>> {
     ///     let pascal = "foo-bar100%baz".to_pascal_case_with_keep("%");
     ///     assert_eq!(pascal, "FooBar100%Baz");
     /// ```
-    fn to_pascal_case_with_keep(&self, keeped: &str) -> String;
+    fn to_pascal_case_with_keep(&self, kept: &str) -> String;
 
     // snake case
 
@@ -337,7 +337,7 @@ pub trait Caser<T: AsRef<str>> {
     ///     let snake = "foo-bar100%baz".to_snake_case_with_keep("%");
     ///     assert_eq!(snake, "foo_bar100%_baz");
     /// ```
-    fn to_snake_case_with_keep(&self, keeped: &str) -> String;
+    fn to_snake_case_with_keep(&self, kept: &str) -> String;
 
     // train case
 
@@ -398,7 +398,7 @@ pub trait Caser<T: AsRef<str>> {
     ///     let train = "foo-bar100%baz".to_train_case_with_keep("%");
     ///     assert_eq!(train, "Foo-Bar100%-Baz");
     /// ```
-    fn to_train_case_with_keep(&self, keeped: &str) -> String;
+    fn to_train_case_with_keep(&self, kept: &str) -> String;
 }
 
 impl<T: AsRef<str>> Caser<T> for T {
@@ -544,8 +544,8 @@ impl<T: AsRef<str>> Caser<T> for T {
         macro_case_with_sep(&self.as_ref(), seps)
     }
 
-    fn to_macro_case_with_keep(&self, keeped: &str) -> String {
-        macro_case_with_keep(&self.as_ref(), keeped)
+    fn to_macro_case_with_keep(&self, kept: &str) -> String {
+        macro_case_with_keep(&self.as_ref(), kept)
     }
 
     // pascal case
@@ -558,8 +558,8 @@ impl<T: AsRef<str>> Caser<T> for T {
         pascal_case_with_sep(&self.as_ref(), seps)
     }
 
-    fn to_pascal_case_with_keep(&self, keeped: &str) -> String {
-        pascal_case_with_keep(&self.as_ref(), keeped)
+    fn to_pascal_case_with_keep(&self, kept: &str) -> String {
+        pascal_case_with_keep(&self.as_ref(), kept)
     }
 
     // snake case
@@ -576,8 +576,8 @@ impl<T: AsRef<str>> Caser<T> for T {
         snake_case_with_sep(&self.as_ref(), seps)
     }
 
-    fn to_snake_case_with_keep(&self, keeped: &str) -> String {
-        snake_case_with_keep(&self.as_ref(), keeped)
+    fn to_snake_case_with_keep(&self, kept: &str) -> String {
+        snake_case_with_keep(&self.as_ref(), kept)
     }
 
     // train case
@@ -594,8 +594,8 @@ impl<T: AsRef<str>> Caser<T> for T {
         train_case_with_sep(&self.as_ref(), seps)
     }
 
-    fn to_train_case_with_keep(&self, keeped: &str) -> String {
-        train_case_with_keep(&self.as_ref(), keeped)
+    fn to_train_case_with_keep(&self, kept: &str) -> String {
+        train_case_with_keep(&self.as_ref(), kept)
     }
 }
 

--- a/src/kebab_case.rs
+++ b/src/kebab_case.rs
@@ -1,321 +1,167 @@
-// Copyright (C) 2024 Takayuki Sato. All Rights Reserved.
+// Copyright (C) 2024-2025 Takayuki Sato. All Rights Reserved.
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
-/// Converts a string to kebab case.
+use crate::options::Options;
+
+/// Converts the input string to kebab case with the specified options.
 ///
-/// This function takes a string slice as its argument, then returns a `String`
-/// of which the case style is kebab case.
+/// ```rust
+///     let opts = stringcase::Options{
+///       separate_before_non_alphabets: true,
+///       separate_after_non_alphabets: true,
+///       separators: "",
+///       keep: "",
+///     };
+///     let kebab = stringcase::kebab_case_with_options("fooBar123Baz", &opts);
+///     assert_eq!(kebab, "foo-bar-123-baz");
+/// ```
+pub fn kebab_case_with_options(input: &str, opts: &Options) -> String {
+    let mut result = String::with_capacity(input.len() + input.len() / 2);
+    // .len returns byte count but ok in this case!
+
+    #[derive(PartialEq)]
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfSepMark,
+        NextOfKeptMark,
+        Other,
+    }
+
+    let mut flag = ChIs::FirstOfStr;
+
+    for ch in input.chars() {
+        if ch.is_ascii_uppercase() {
+            if flag == ChIs::FirstOfStr {
+                result.push(ch.to_ascii_lowercase());
+                flag = ChIs::NextOfUpper;
+            } else if flag == ChIs::NextOfUpper
+                || flag == ChIs::NextOfContdUpper
+                || (!opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
+            {
+                result.push(ch.to_ascii_lowercase());
+                flag = ChIs::NextOfContdUpper;
+            } else {
+                result.push('-');
+                result.push(ch.to_ascii_lowercase());
+                flag = ChIs::NextOfUpper;
+            }
+        } else if ch.is_ascii_lowercase() {
+            if flag == ChIs::NextOfContdUpper {
+                if let Some(prev) = result.pop() {
+                    result.push('-');
+                    result.push(prev);
+                    result.push(ch);
+                }
+            } else if flag == ChIs::NextOfSepMark
+                || (opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
+            {
+                result.push('-');
+                result.push(ch);
+            } else {
+                result.push(ch);
+            }
+            flag = ChIs::Other;
+        } else {
+            let mut is_kept_char = false;
+            if ch.is_ascii_digit() {
+                is_kept_char = true;
+            } else if !opts.separators.is_empty() {
+                if !opts.separators.contains(ch) {
+                    is_kept_char = true;
+                }
+            } else if !opts.keep.is_empty() {
+                if opts.keep.contains(ch) {
+                    is_kept_char = true;
+                }
+            }
+
+            if is_kept_char {
+                if opts.separate_before_non_alphabets {
+                    if flag == ChIs::FirstOfStr || flag == ChIs::NextOfKeptMark {
+                        result.push(ch);
+                    } else {
+                        result.push('-');
+                        result.push(ch);
+                    }
+                } else {
+                    if flag != ChIs::NextOfSepMark {
+                        result.push(ch);
+                    } else {
+                        result.push('-');
+                        result.push(ch);
+                    }
+                }
+                flag = ChIs::NextOfKeptMark;
+            } else {
+                if flag != ChIs::FirstOfStr {
+                    flag = ChIs::NextOfSepMark;
+                }
+            }
+        }
+    }
+
+    result
+}
+
+/// Converts the input string to kebab case.
 ///
-/// This function targets the upper and lower cases of ASCII alphabets for
-/// capitalization, and all characters except ASCII alphabets and ASCII numbers
-/// are replaced to hyphens as word separators.
+/// It treats the end of a sequence of non-alphabetical characters as a word boundary, but not
+/// the beginning.
 ///
 /// ```rust
 ///     let kebab = stringcase::kebab_case("fooBar123Baz");
 ///     assert_eq!(kebab, "foo-bar123-baz");
 /// ```
 pub fn kebab_case(input: &str) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
-
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeepedMark,
-        Others,
-    }
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if ch.is_ascii_uppercase() {
-            match flag {
-                ChIs::FirstOfStr => {
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfUpper;
-                }
-                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfContdUpper;
-                }
-                _ => {
-                    result.push('-');
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfUpper;
-                }
-            }
-        } else if ch.is_ascii_lowercase() {
-            match flag {
-                ChIs::NextOfContdUpper => match result.pop() {
-                    Some(prev) => {
-                        result.push('-');
-                        result.push(prev);
-                    }
-                    None => (), // impossible
-                },
-                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
-                    result.push('-');
-                }
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::Others;
-        } else if ch.is_ascii_digit() {
-            match flag {
-                ChIs::NextOfSepMark => result.push('-'),
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::NextOfKeepedMark;
-        } else {
-            match flag {
-                ChIs::FirstOfStr => (),
-                _ => flag = ChIs::NextOfSepMark,
-            }
-        }
-    }
-
-    result
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "",
+    };
+    kebab_case_with_options(input, &opts)
 }
 
-/// Converts a string to kebab case.
-///
-/// This function takes a string slice as its argument, then returns a `String`
-/// of which the case style is kebab case.
-///
-/// This function targets the upper and lower cases of ASCII alphabets and ASCII numbers
-/// for capitalization, and all characters except ASCII alphabets and ASCII numbers
-/// are replaced to hyphens as word separators.
-///
-/// ```rust
-///     let kebab = stringcase::kebab_case_with_nums_as_word("fooBar123Baz");
-///     assert_eq!(kebab, "foo-bar-123-baz");
-/// ```
-pub fn kebab_case_with_nums_as_word(input: &str) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
-
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeepedMark, // = next of number
-        Others,
-    }
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if ch.is_ascii_uppercase() {
-            match flag {
-                ChIs::FirstOfStr => {
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfUpper;
-                }
-                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfContdUpper;
-                }
-                _ => {
-                    result.push('-');
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfUpper;
-                }
-            }
-        } else if ch.is_ascii_lowercase() {
-            match flag {
-                ChIs::NextOfContdUpper => match result.pop() {
-                    Some(prev) => {
-                        result.push('-');
-                        result.push(prev);
-                    }
-                    None => (), // impossible
-                },
-                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
-                    result.push('-');
-                }
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::Others;
-        } else if ch.is_ascii_digit() {
-            match flag {
-                ChIs::FirstOfStr => (),
-                ChIs::NextOfKeepedMark => (),
-                _ => result.push('-'),
-            }
-            result.push(ch);
-            flag = ChIs::NextOfKeepedMark;
-        } else {
-            match flag {
-                ChIs::FirstOfStr => (),
-                _ => flag = ChIs::NextOfSepMark,
-            }
-        }
-    }
-
-    result
-}
-
-/// Converts a string to kebab case using the specified characters as
-/// separators.
-///
-/// This function takes a string slice as its argument, then returns a `String`
-/// of which the case style is kebab case.
-///
-/// This function targets only the upper and lower cases of ASCII alphabets for
-/// capitalization, and the characters specified as the second argument of this
-/// function are regarded as word separators and are replaced to hyphens.
-///
-/// ```rust
-///     let kebab = stringcase::kebab_case_with_sep("foo-Bar100%Baz", "- ");
-///     assert_eq!(kebab, "foo-bar100%-baz");
-/// ```
+/// Converts the input string to kebab case with the specified separator characters.
+#[deprecated(since = "0.4.0", note = "Should use kebab_case_with_options instead")]
 pub fn kebab_case_with_sep(input: &str, seps: &str) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
-
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeepedMark,
-        Others,
-    }
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if seps.contains(ch) {
-            match flag {
-                ChIs::FirstOfStr => (),
-                _ => flag = ChIs::NextOfSepMark,
-            }
-        } else if ch.is_ascii_uppercase() {
-            match flag {
-                ChIs::FirstOfStr => {
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfUpper;
-                }
-                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfContdUpper;
-                }
-                _ => {
-                    result.push('-');
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfUpper;
-                }
-            }
-        } else if ch.is_ascii_lowercase() {
-            match flag {
-                ChIs::NextOfContdUpper => match result.pop() {
-                    Some(prev) => {
-                        result.push('-');
-                        result.push(prev);
-                    }
-                    None => (), // impossible
-                },
-                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
-                    result.push('-');
-                }
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::Others;
-        } else {
-            match flag {
-                ChIs::NextOfSepMark => result.push('-'),
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::NextOfKeepedMark;
-        }
-    }
-
-    result
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: seps,
+        keep: "",
+    };
+    kebab_case_with_options(input, &opts)
 }
 
-/// Converts a string to kebab case using characters other than the specified
-/// characters as separators.
-///
-/// This function takes a string slice as its argument, then returns a `String`
-/// of which the case style is kebab case.
-///
-/// This function targets only the upper and lower cases of ASCII alphabets for
-/// capitalization, and the characters other than the specified characters as
-/// the second argument of this function are regarded as word separators and
-/// are replaced to hyphens.
-///
-/// ```rust
-///     let kebab = stringcase::kebab_case_with_keep("foo-Bar100%Baz", "%");
-///     assert_eq!(kebab, "foo-bar100%-baz");
-/// ```
-pub fn kebab_case_with_keep(input: &str, keeped: &str) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
+/// Converts the input string to kebab case with the specified characters to be kept.
+#[deprecated(since = "0.4.0", note = "Should use kebab_case_with_options instead")]
+pub fn kebab_case_with_keep(input: &str, kept: &str) -> String {
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: kept,
+    };
+    kebab_case_with_options(input, &opts)
+}
 
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeepedMark,
-        Others,
-    }
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if ch.is_ascii_uppercase() {
-            match flag {
-                ChIs::FirstOfStr => {
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfUpper;
-                }
-                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfContdUpper;
-                }
-                _ => {
-                    result.push('-');
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfUpper;
-                }
-            }
-        } else if ch.is_ascii_lowercase() {
-            match flag {
-                ChIs::NextOfContdUpper => match result.pop() {
-                    Some(prev) => {
-                        result.push('-');
-                        result.push(prev);
-                    }
-                    None => (), // impossible
-                },
-                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
-                    result.push('-');
-                }
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::Others;
-        } else if ch.is_ascii_digit() || keeped.contains(ch) {
-            match flag {
-                ChIs::NextOfSepMark => result.push('-'),
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::NextOfKeepedMark;
-        } else {
-            match flag {
-                ChIs::FirstOfStr => (),
-                _ => flag = ChIs::NextOfSepMark,
-            }
-        }
-    }
-
-    result
+/// Converts the input string to kebab case.
+///
+/// It treats the beginning and the end of a sequence of non-alphabetical characters as a word
+/// boundary.
+#[deprecated(since = "0.4.0", note = "Should use kebab_case_with_options instead")]
+pub fn kebab_case_with_nums_as_word(input: &str) -> String {
+    let opts = Options {
+        separate_before_non_alphabets: true,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "",
+    };
+    kebab_case_with_options(input, &opts)
 }
 
 #[cfg(test)]
@@ -323,383 +169,2136 @@ mod tests_of_kebab_case {
     use super::*;
 
     #[test]
-    fn it_should_convert_camel_case() {
+    fn convert_camel_case() {
         let result = kebab_case("abcDefGHIjk");
         assert_eq!(result, "abc-def-gh-ijk");
     }
 
     #[test]
-    fn it_should_convert_pascal_case() {
+    fn convert_pascal_case() {
         let result = kebab_case("AbcDefGHIjk");
         assert_eq!(result, "abc-def-gh-ijk");
     }
 
     #[test]
-    fn it_should_convert_snake_case() {
+    fn convert_snake_case() {
         let result = kebab_case("abc_def_ghi");
         assert_eq!(result, "abc-def-ghi");
     }
 
     #[test]
-    fn it_should_convert_kebab_case() {
+    fn convert_kebab_case() {
         let result = kebab_case("abc-def-ghi");
         assert_eq!(result, "abc-def-ghi");
     }
 
     #[test]
-    fn it_should_convert_train_case() {
+    fn convert_train_case() {
         let result = kebab_case("Abc-Def-Ghi");
         assert_eq!(result, "abc-def-ghi");
     }
 
     #[test]
-    fn it_should_convert_macro_case() {
+    fn convert_macro_case() {
         let result = kebab_case("ABC_DEF_GHI");
         assert_eq!(result, "abc-def-ghi");
     }
 
     #[test]
-    fn it_should_convert_cobol_case() {
+    fn convert_cobol_case() {
         let result = kebab_case("ABC-DEF-GHI");
         assert_eq!(result, "abc-def-ghi");
     }
 
     #[test]
-    fn it_should_keep_digits() {
-        let result = kebab_case("abc123-456defG789HIJklMN12");
-        assert_eq!(result, "abc123-456-def-g789-hi-jkl-mn12");
+    fn convert_with_keeping_digits() {
+        let result = kebab_case("abc123-456defG89HIJklMN12");
+        assert_eq!(result, "abc123-456-def-g89-hi-jkl-mn12");
     }
 
     #[test]
-    fn it_should_convert_when_starting_with_digit() {
-        let result = kebab_case("123abc456def");
-        assert_eq!(result, "123-abc456-def");
-
-        let result = kebab_case("123ABC456DEF");
-        assert_eq!(result, "123-abc456-def");
-    }
-
-    #[test]
-    fn it_should_treat_marks_as_separators() {
+    fn convert_with_symbols_as_separators() {
         let result = kebab_case(":.abc~!@def#$ghi%&jk(lm)no/?");
         assert_eq!(result, "abc-def-ghi-jk-lm-no");
     }
 
     #[test]
-    fn it_should_convert_empty() {
+    fn convert_when_starting_with_digit() {
+        let result = kebab_case("123abc456def");
+        assert_eq!(result, "123-abc456-def");
+
+        let result = kebab_case("123ABC456DEF");
+        assert_eq!(result, "123-abc456-def");
+
+        let result = kebab_case("123Abc456Def");
+        assert_eq!(result, "123-abc456-def");
+    }
+
+    #[test]
+    fn convert_empty_string() {
         let result = kebab_case("");
         assert_eq!(result, "");
     }
-
-    #[test]
-    fn it_should_treat_number_sequence_by_default() {
-        let result = kebab_case("abc123Def456#Ghi789");
-        assert_eq!(result, "abc123-def456-ghi789");
-
-        let result = kebab_case("ABC123-DEF456#GHI789");
-        assert_eq!(result, "abc123-def456-ghi789");
-
-        let result = kebab_case("abc123-def456#ghi789");
-        assert_eq!(result, "abc123-def456-ghi789");
-
-        let result = kebab_case("ABC123_DEF456#GHI789");
-        assert_eq!(result, "abc123-def456-ghi789");
-
-        let result = kebab_case("Abc123Def456#Ghi789");
-        assert_eq!(result, "abc123-def456-ghi789");
-
-        let result = kebab_case("abc123_def456#ghi789");
-        assert_eq!(result, "abc123-def456-ghi789");
-
-        let result = kebab_case("Abc123-Def456#-Ghi789");
-        assert_eq!(result, "abc123-def456-ghi789");
-
-        let result = kebab_case("000-abc123_def456#ghi789");
-        assert_eq!(result, "000-abc123-def456-ghi789");
-    }
 }
 
 #[cfg(test)]
-mod tests_of_kebab_case_with_nums_as_word {
+mod tests_of_cobol_case_with_options {
     use super::*;
 
-    #[test]
-    fn it_should_convert_camel_case() {
-        let result = kebab_case_with_nums_as_word("abcDefGHIjk");
-        assert_eq!(result, "abc-def-gh-ijk");
+    mod non_alphabets_as_head_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc-123-456def-g-89hi-jkl-mn-12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "abc-def-ghi-jk-lm-no");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123abc-456def");
+
+            let result = kebab_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc-456def");
+
+            let result = kebab_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123-abc-456-def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_pascal_case() {
-        let result = kebab_case_with_nums_as_word("AbcDefGHIjk");
-        assert_eq!(result, "abc-def-gh-ijk");
+    mod non_alphabets_as_tail_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123-456-def-g89-hi-jkl-mn12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "abc-def-ghi-jk-lm-no");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123-abc456-def");
+
+            let result = kebab_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123-abc456-def");
+
+            let result = kebab_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123-abc456-def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_snake_case() {
-        let result = kebab_case_with_nums_as_word("abc_def_ghi");
-        assert_eq!(result, "abc-def-ghi");
+    mod non_alphabets_as_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc-123-456-def-g-89-hi-jkl-mn-12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "abc-def-ghi-jk-lm-no");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123-abc-456-def");
+
+            let result = kebab_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123-abc-456-def");
+
+            let result = kebab_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123-abc-456-def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_kebab_case() {
-        let result = kebab_case_with_nums_as_word("abc-def-ghi");
-        assert_eq!(result, "abc-def-ghi");
+    mod non_alphabets_as_part_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123-456def-g89hi-jkl-mn12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "abc-def-ghi-jk-lm-no");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123abc456def");
+
+            let result = kebab_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc456def");
+
+            let result = kebab_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123-abc456-def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_train_case() {
-        let result = kebab_case_with_nums_as_word("Abc-Def-Ghi");
-        assert_eq!(result, "abc-def-ghi");
+    mod non_alphabets_as_head_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "-";
+            result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc-_def-_ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "_";
+            result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc--def--ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "_";
+            result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc---def---ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "-";
+            result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc-_def-_ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "_";
+            result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc--def--ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc-123-456def-g-89hi-jkl-mn-12");
+
+            opts.separators = "_";
+            result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc-123-456def-g-89hi-jkl-mn-12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: ":@$&()/",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".abc-~!-def-#-ghi-%-jk-lm-no-?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123abc-456def");
+
+            let result = kebab_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc-456def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
+
+        #[test]
+        fn alphabets_and_numbers_in_separators_are_no_effect() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-b2",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abc123def", &opts);
+            assert_eq!(result, "abc-123def");
+        }
     }
 
-    #[test]
-    fn it_should_convert_macro_case() {
-        let result = kebab_case_with_nums_as_word("ABC_DEF_GHI");
-        assert_eq!(result, "abc-def-ghi");
+    mod non_alphabets_as_tail_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "-";
+            result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_-def_-ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "_";
+            result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc--def--ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "_";
+            result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc--def--ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "-";
+            result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_-def_-ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "_";
+            result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc--def--ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123-456-def-g89-hi-jkl-mn12");
+
+            opts.separators = "_";
+            result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123-456-def-g89-hi-jkl-mn12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: ":@$&()/",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".-abc~!-def#-ghi%-jk-lm-no-?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123-abc456-def");
+
+            let result = kebab_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123-abc456-def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
+
+        #[test]
+        fn alphabets_and_numbers_in_separators_are_no_effect() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-b2",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abc123def", &opts);
+            assert_eq!(result, "abc123-def");
+        }
     }
 
-    #[test]
-    fn it_should_convert_cobol_case() {
-        let result = kebab_case_with_nums_as_word("ABC-DEF-GHI");
-        assert_eq!(result, "abc-def-ghi");
+    mod non_alphabets_as_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "-";
+            result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc-_-def-_-ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "_";
+            result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc---def---ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "_";
+            result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc---def---ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "-";
+            result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc-_-def-_-ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "_";
+            result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc---def---ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc-123-456-def-g-89-hi-jkl-mn-12");
+
+            opts.separators = "_";
+            result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc-123-456-def-g-89-hi-jkl-mn-12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: ":@$&()/",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".-abc-~!-def-#-ghi-%-jk-lm-no-?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123-abc-456-def");
+
+            let result = kebab_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123-abc-456-def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
+
+        #[test]
+        fn alphabets_and_numbers_in_separators_are_no_effect() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-b2",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abc123def", &opts);
+            assert_eq!(result, "abc-123-def");
+        }
     }
 
-    #[test]
-    fn it_should_keep_digits() {
-        let result = kebab_case_with_nums_as_word("abc123-456defG789HIJklMN12");
-        assert_eq!(result, "abc-123-456-def-g-789-hi-jkl-mn-12");
+    mod non_alphabets_as_part_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "-";
+            result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "_";
+            result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "_";
+            result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc--def--ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "-";
+            result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.separators = "_";
+            result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123-456def-g89hi-jkl-mn12");
+
+            opts.separators = "_";
+            result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123-456def-g89hi-jkl-mn12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: ":@$&()/",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".abc~!-def#-ghi%-jk-lm-no-?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123abc456def");
+
+            let result = kebab_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc456def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
+
+        #[test]
+        fn alphabets_and_numbers_in_separators_are_no_effect() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-b2",
+                keep: "",
+            };
+
+            let result = kebab_case_with_options("abc123def", &opts);
+            assert_eq!(result, "abc123def");
+        }
     }
 
-    #[test]
-    fn it_should_convert_when_starting_with_digit() {
-        let result = kebab_case_with_nums_as_word("123abc456def");
-        assert_eq!(result, "123-abc-456-def");
+    mod non_alphabets_as_head_of_a_word_with_kept_characters {
+        use super::*;
 
-        let result = kebab_case_with_nums_as_word("123ABC456DEF");
-        assert_eq!(result, "123-abc-456-def");
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = kebab_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = kebab_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+
+            let mut result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.keep = "_";
+            result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc-_def-_ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.keep = "-";
+            result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc--def--ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.keep = "-";
+            result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc---def---ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+
+            let mut result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.keep = "_";
+            result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc-_def-_ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.keep = "-";
+            result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc--def--ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc-123-456def-g-89hi-jkl-mn-12");
+
+            opts.keep = "-";
+            result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc-123-456def-g-89hi-jkl-mn-12");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+
+            let result = kebab_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123abc-456def");
+
+            let result = kebab_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc-456def");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: ".~!#%?",
+            };
+
+            let result = kebab_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".abc-~!-def-#-ghi-%-jk-lm-no-?");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = kebab_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_treat_marks_as_separators() {
-        let result = kebab_case_with_nums_as_word(":.abc~!@def#$ghi%&jk(lm)no/?");
-        assert_eq!(result, "abc-def-ghi-jk-lm-no");
+    mod non_alphabets_as_tail_of_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = kebab_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = kebab_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+
+            let mut result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.keep = "_";
+            result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_-def_-ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.keep = "-";
+            result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc--def--ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.keep = "-";
+            result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc--def--ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+
+            let mut result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.keep = "_";
+            result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_-def_-ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.keep = "-";
+            result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc--def--ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123-456-def-g89-hi-jkl-mn12");
+
+            opts.keep = "-";
+            result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123-456-def-g89-hi-jkl-mn12");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+
+            let result = kebab_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123-abc456-def");
+
+            opts.keep = "_";
+            let result = kebab_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123-abc456-def");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: ".~!#%?",
+            };
+
+            let result = kebab_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".-abc~!-def#-ghi%-jk-lm-no-?");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = kebab_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_empty() {
-        let result = kebab_case_with_nums_as_word("");
-        assert_eq!(result, "");
+    mod non_alphabets_as_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = kebab_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = kebab_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+
+            let mut result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.keep = "_";
+            result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc-_-def-_-ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.keep = "-";
+            result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc---def---ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.keep = "-";
+            result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc---def---ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+
+            let mut result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.keep = "_";
+            result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc-_-def-_-ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+
+            opts.keep = "-";
+            result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc---def---ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc-123-456-def-g-89-hi-jkl-mn-12");
+
+            opts.keep = "-";
+            result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc-123-456-def-g-89-hi-jkl-mn-12");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+
+            let result = kebab_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123-abc-456-def");
+
+            let result = kebab_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123-abc-456-def");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: ".~!#%?",
+            };
+
+            let result = kebab_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".-abc-~!-def-#-ghi-%-jk-lm-no-?");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = kebab_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_treat_number_sequence_as_word() {
-        let result = kebab_case_with_nums_as_word("abc123Def456#Ghi789");
-        assert_eq!(result, "abc-123-def-456-ghi-789");
+    mod non_alphabets_as_part_of_a_word_with_kept_characters {
+        use super::*;
 
-        let result = kebab_case_with_nums_as_word("ABC123-DEF456#GHI789");
-        assert_eq!(result, "abc-123-def-456-ghi-789");
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
 
-        let result = kebab_case_with_nums_as_word("abc123-def456#ghi789");
-        assert_eq!(result, "abc-123-def-456-ghi-789");
+            let result = kebab_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
 
-        let result = kebab_case_with_nums_as_word("ABC123_DEF456#GHI789");
-        assert_eq!(result, "abc-123-def-456-ghi-789");
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
 
-        let result = kebab_case_with_nums_as_word("Abc123Def456#Ghi789");
-        assert_eq!(result, "abc-123-def-456-ghi-789");
+            let result = kebab_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc-def-gh-ijk");
+        }
 
-        let result = kebab_case_with_nums_as_word("abc123_def456#ghi789");
-        assert_eq!(result, "abc-123-def-456-ghi-789");
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
 
-        let result = kebab_case_with_nums_as_word("Abc123-Def456#-Ghi789");
-        assert_eq!(result, "abc-123-def-456-ghi-789");
+            let mut result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
 
-        let result = kebab_case_with_nums_as_word("000-abc123_def456#ghi789");
-        assert_eq!(result, "000-abc-123-def-456-ghi-789");
-    }
-}
+            opts.keep = "_";
+            result = kebab_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
 
-#[cfg(test)]
-mod tests_of_kebab_case_with_sep {
-    use super::*;
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
 
-    #[test]
-    fn it_should_convert_camel_case() {
-        let result = kebab_case_with_sep("abcDefGHIjk", "-_");
-        assert_eq!(result, "abc-def-gh-ijk");
-    }
+            let mut result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
 
-    #[test]
-    fn it_should_convert_pascal_case() {
-        let result = kebab_case_with_sep("AbcDefGHIjk", "-_");
-        assert_eq!(result, "abc-def-gh-ijk");
-    }
+            opts.keep = "-";
+            result = kebab_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
 
-    #[test]
-    fn it_should_convert_snake_case() {
-        let result = kebab_case_with_sep("abc_def_ghi", "_");
-        assert_eq!(result, "abc-def-ghi");
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
 
-        let result = kebab_case_with_sep("abc_def_ghi", "-");
-        assert_eq!(result, "abc_-def_-ghi");
-    }
+            let mut result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
 
-    #[test]
-    fn it_should_convert_kebab_case() {
-        let result = kebab_case_with_sep("abc-def-ghi", "-");
-        assert_eq!(result, "abc-def-ghi");
+            opts.keep = "-";
+            result = kebab_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc--def--ghi");
+        }
 
-        let result = kebab_case_with_sep("abc-def-ghi", "_");
-        assert_eq!(result, "abc--def--ghi");
-    }
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
 
-    #[test]
-    fn it_should_convert_train_case() {
-        let result = kebab_case_with_sep("Abc-Def-Ghi", "-");
-        assert_eq!(result, "abc-def-ghi");
+            let mut result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
 
-        let result = kebab_case_with_sep("Abc-Def-Ghi", "_");
-        assert_eq!(result, "abc--def--ghi");
-    }
+            opts.keep = "_";
+            result = kebab_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
 
-    #[test]
-    fn it_should_convert_macro_case() {
-        let result = kebab_case_with_sep("ABC_DEF_GHI", "_");
-        assert_eq!(result, "abc-def-ghi");
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
 
-        let result = kebab_case_with_sep("ABC_DEF_GHI", "-");
-        assert_eq!(result, "abc_-def_-ghi");
-    }
+            let mut result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
 
-    #[test]
-    fn it_should_convert_cobol_case() {
-        let result = kebab_case_with_sep("ABC-DEF-GHI", "-");
-        assert_eq!(result, "abc-def-ghi");
+            opts.keep = "-";
+            result = kebab_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
 
-        let result = kebab_case_with_sep("ABC-DEF-GHI", "_");
-        assert_eq!(result, "abc--def--ghi");
-    }
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
 
-    #[test]
-    fn it_should_keep_digits() {
-        let result = kebab_case_with_sep("abc123-456defG789HIJklMN12", "-");
-        assert_eq!(result, "abc123-456-def-g789-hi-jkl-mn12");
+            let mut result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123-456def-g89hi-jkl-mn12");
 
-        let result = kebab_case_with_sep("abc123-456defG789HIJklMN12", "_");
-        assert_eq!(result, "abc123-456-def-g789-hi-jkl-mn12");
-    }
+            opts.keep = "-";
+            result = kebab_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123-456def-g89hi-jkl-mn12");
+        }
 
-    #[test]
-    fn it_should_convert_when_starting_with_digit() {
-        let result = kebab_case_with_sep("123abc456def", "-");
-        assert_eq!(result, "123-abc456-def");
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
 
-        let result = kebab_case_with_sep("123ABC456DEF", "-");
-        assert_eq!(result, "123-abc456-def");
-    }
+            let result = kebab_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123abc456def");
 
-    #[test]
-    fn it_should_treat_marks_as_separators() {
-        let result = kebab_case_with_sep(":.abc~!@def#$ghi%&jk(lm)no/?", ":@$&()/");
-        assert_eq!(result, ".-abc~!-def#-ghi%-jk-lm-no-?");
-    }
+            let result = kebab_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc456def");
+        }
 
-    #[test]
-    fn it_should_convert_empty() {
-        let result = kebab_case_with_sep("", "_-");
-        assert_eq!(result, "");
-    }
-}
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: ".~!#%?",
+            };
 
-#[cfg(test)]
-mod tests_of_kebab_case_with_keep {
-    use super::*;
+            let result = kebab_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".abc~!-def#-ghi%-jk-lm-no-?");
+        }
 
-    #[test]
-    fn it_should_convert_camel_case() {
-        let result = kebab_case_with_keep("abcDefGHIjk", "-_");
-        assert_eq!(result, "abc-def-gh-ijk");
-    }
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
 
-    #[test]
-    fn it_should_convert_pascal_case() {
-        let result = kebab_case_with_keep("AbcDefGHIjk", "-_");
-        assert_eq!(result, "abc-def-gh-ijk");
-    }
-
-    #[test]
-    fn it_should_convert_snake_case() {
-        let result = kebab_case_with_keep("abc_def_ghi", "-");
-        assert_eq!(result, "abc-def-ghi");
-
-        let result = kebab_case_with_keep("abc_def_ghi", "_");
-        assert_eq!(result, "abc_-def_-ghi");
-    }
-
-    #[test]
-    fn it_should_convert_kebab_case() {
-        let result = kebab_case_with_keep("abc-def-ghi", "_");
-        assert_eq!(result, "abc-def-ghi");
-
-        let result = kebab_case_with_keep("abc-def-ghi", "-");
-        assert_eq!(result, "abc--def--ghi");
-    }
-
-    #[test]
-    fn it_should_convert_train_case() {
-        let result = kebab_case_with_keep("Abc-Def-Ghi", "_");
-        assert_eq!(result, "abc-def-ghi");
-
-        let result = kebab_case_with_keep("Abc-Def-Ghi", "-");
-        assert_eq!(result, "abc--def--ghi");
-    }
-
-    #[test]
-    fn it_should_convert_macro_case() {
-        let result = kebab_case_with_keep("ABC_DEF_GHI", "-");
-        assert_eq!(result, "abc-def-ghi");
-
-        let result = kebab_case_with_keep("ABC_DEF_GHI", "_");
-        assert_eq!(result, "abc_-def_-ghi");
-    }
-
-    #[test]
-    fn it_should_convert_cobol_case() {
-        let result = kebab_case_with_keep("ABC-DEF-GHI", "_");
-        assert_eq!(result, "abc-def-ghi");
-
-        let result = kebab_case_with_keep("ABC-DEF-GHI", "-");
-        assert_eq!(result, "abc--def--ghi");
-    }
-
-    #[test]
-    fn it_should_keep_digits() {
-        let result = kebab_case_with_keep("abc123-456defG789HIJklMN12", "_");
-        assert_eq!(result, "abc123-456-def-g789-hi-jkl-mn12");
-
-        let result = kebab_case_with_keep("abc123-456defG789HIJklMN12", "-");
-        assert_eq!(result, "abc123-456-def-g789-hi-jkl-mn12");
-    }
-
-    #[test]
-    fn it_should_convert_when_starting_with_digit() {
-        let result = kebab_case_with_keep("123abc456def", "-");
-        assert_eq!(result, "123-abc456-def");
-
-        let result = kebab_case_with_keep("123ABC456DEF", "-");
-        assert_eq!(result, "123-abc456-def");
-    }
-
-    #[test]
-    fn it_should_treat_marks_as_separators() {
-        let result = kebab_case_with_keep(":.abc~!@def#$ghi%&jk(lm)no/?", ".~!#%?");
-        assert_eq!(result, ".-abc~!-def#-ghi%-jk-lm-no-?");
-    }
-
-    #[test]
-    fn it_should_convert_empty() {
-        let result = kebab_case_with_sep("", "_-");
-        assert_eq!(result, "");
+            let result = kebab_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 }

--- a/tests/caser_test.rs
+++ b/tests/caser_test.rs
@@ -80,19 +80,37 @@ fn it_should_convert_to_kebab_case_by_method_of_string() {
 
 #[test]
 fn it_should_convert_to_kebab_case_with_nums_as_word_by_method_of_string() {
-    let converted = "foo_bar100BAZQux".to_kebab_case_with_nums_as_word();
+    let opts = Options {
+        separate_before_non_alphabets: true,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "",
+    };
+    let converted = "foo_bar100BAZQux".to_kebab_case_with_options(&opts);
     assert_eq!(converted, "foo-bar-100-baz-qux");
 }
 
 #[test]
 fn it_should_convert_to_kebab_case_with_sep_by_method_of_string() {
-    let converted = "foo_bar100BAZQux".to_kebab_case_with_sep("_");
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "_",
+        keep: "",
+    };
+    let converted = "foo_bar100BAZQux".to_kebab_case_with_options(&opts);
     assert_eq!(converted, "foo-bar100-baz-qux");
 }
 
 #[test]
 fn it_should_convert_to_kebab_case_with_keep_by_method_of_string() {
-    let converted = "foo_bar100BAZQux".to_kebab_case_with_keep("#");
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "#",
+    };
+    let converted = "foo_bar100BAZQux".to_kebab_case_with_options(&opts);
     assert_eq!(converted, "foo-bar100-baz-qux");
 }
 

--- a/tests/kebab_case_test.rs
+++ b/tests/kebab_case_test.rs
@@ -1,4 +1,4 @@
-use stringcase::{kebab_case, kebab_case_with_keep, kebab_case_with_sep};
+use stringcase::{kebab_case, kebab_case_with_options, Options};
 
 #[test]
 fn it_should_convert_to_kebab_case() {
@@ -8,20 +8,37 @@ fn it_should_convert_to_kebab_case() {
 
 #[test]
 fn it_should_convert_to_kebab_case_with_sep() {
-    let converted = kebab_case_with_sep("foo_bar100%BAZQux", "_");
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "_",
+        keep: "",
+    };
+    let converted = kebab_case_with_options("foo_bar100%BAZQux", &opts);
     assert_eq!(converted, "foo-bar100%-baz-qux");
 }
 
 #[test]
 fn it_should_convert_to_kebab_case_with_keep() {
-    let converted = kebab_case_with_keep("foo_bar100%BAZQux", "%");
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "%",
+    };
+    let converted = kebab_case_with_options("foo_bar100%BAZQux", &opts);
     assert_eq!(converted, "foo-bar100%-baz-qux");
 }
 
 #[test]
 fn it_should_convert_to_kebab_case_with_nums_as_word() {
-    use stringcase::kebab_case_with_nums_as_word as kebab_case;
+    let opts = Options {
+        separate_before_non_alphabets: true,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "",
+    };
 
-    let converted = kebab_case("foo-bar100%-baz-qux");
+    let converted = kebab_case_with_options("foo-bar100%-baz-qux", &opts);
     assert_eq!(converted, "foo-bar-100-baz-qux");
 }


### PR DESCRIPTION
(Related to #24)

This PR adds the new function `kebab_case_with_options`, which supports handling non alphabetical characters, separators, and kept characters with `Options`.

`kebab_case` is changed to use this function inside, and `kebab_case_with_nums_as_word`,  `kebab_case_with_sep` and `kebab_case_with_keep` are deprecated.