### PR TITLE
new!: added macro_case_with_options and made use it in existing macro case functions

### DIFF
--- a/src/caser.rs
+++ b/src/caser.rs
@@ -172,63 +172,57 @@ pub trait Caser<T: AsRef<str>> {
 
     // macro case
 
-    /// Converts a string to macro case.
+    /// Converts the input string to macro case.
     ///
-    /// This method targets the upper and lower cases of ASCII alphabets for
-    /// capitalization, and all characters except ASCII alphabets and ASCII numbers
-    /// are replaced to underscores as word separators.
+    /// It treats the end of a sequence of non-alphabetical characters as a word boundary,
+    /// but not the beginning.
     ///
     /// ```rust
     ///     use stringcase::Caser;
     ///
-    ///     let macro_ = "foo-bar100%baz".to_macro_case();
-    ///     assert_eq!(macro_, "FOO_BAR100_BAZ");
+    ///     let result = "foo_bar_baz".to_macro_case();
+    ///     assert_eq!(result, "FOO_BAR_BAZ");
     /// ```
     fn to_macro_case(&self) -> String;
 
-    /// Converts a string to macro case.
-    ///
-    /// This method targets the upper and lower cases of ASCII alphabets and
-    /// ASCII numbers for capitalization, and all characters except ASCII
-    /// alphabets and ASCII numbers are replaced to underscores as word separators.
+    /// Converts the input string to macro case with the specified options.
     ///
     /// ```rust
     ///     use stringcase::Caser;
     ///
-    ///     let macro_ = "foo-bar100%baz".to_macro_case_with_nums_as_word();
-    ///     assert_eq!(macro_, "FOO_BAR_100_BAZ");
+    ///     let opts = stringcase::Options{
+    ///       separate_before_non_alphabets: true,
+    ///       separate_after_non_alphabets: true,
+    ///       separators: "",
+    ///       keep: "",
+    ///     };
+    ///     let result = "foo_bar_100_baz".to_macro_case_with_options(&opts);
+    ///     assert_eq!(result, "FOO_BAR_100_BAZ");
     /// ```
+    fn to_macro_case_with_options(&self, opts: &Options) -> String;
+
+    /// Converts the input string to macro case.
+    ///
+    /// It treats the begin and the end of a sequence of non-alphabetical characters as a word
+    /// boundary.
+    #[deprecated(
+        since = "0.4.0",
+        note = "Should use to_macro_case_with_options instead"
+    )]
     fn to_macro_case_with_nums_as_word(&self) -> String;
 
-    /// Converts a string to macro case using the specified characters as
-    /// separators.
-    ///
-    /// This method targets only the upper and lower cases of ASCII alphabets for
-    /// capitalization, and the characters specified as the second argument of this
-    /// method are regarded as word separators and are replaced to underscores.
-    ///
-    /// ```rust
-    ///     use stringcase::Caser;
-    ///
-    ///     let macro_ = "foo-bar100%baz".to_macro_case_with_sep("- ");
-    ///     assert_eq!(macro_, "FOO_BAR100%_BAZ");
-    /// ```
+    /// Converts the input string to macro case with the specified separator characters.
+    #[deprecated(
+        since = "0.4.0",
+        note = "Should use to_macro_case_with_options instead"
+    )]
     fn to_macro_case_with_sep(&self, seps: &str) -> String;
 
-    /// Converts a string to macro case using characters other than the specified
-    /// characters as separators.
-    ///
-    /// This method targets only the upper and lower cases of ASCII alphabets for
-    /// capitalization, and the characters other than the specified characters as
-    /// the second argument of this method are regarded as word separators and are
-    /// replaced to underscores.
-    ///
-    /// ```rust
-    ///     use stringcase::Caser;
-    ///
-    ///     let macro_ = "foo-bar100%baz".to_macro_case_with_keep("%");
-    ///     assert_eq!(macro_, "FOO_BAR100%_BAZ");
-    /// ```
+    /// Converts the input string to macro case with the specified characters to be kept.
+    #[deprecated(
+        since = "0.4.0",
+        note = "Should use to_macro_case_with_options instead"
+    )]
     fn to_macro_case_with_keep(&self, kept: &str) -> String;
 
     // pascal case
@@ -533,19 +527,47 @@ impl<T: AsRef<str>> Caser<T> for T {
     // macro case
 
     fn to_macro_case(&self) -> String {
-        macro_case(&self.as_ref())
+        let opts = Options {
+            separate_before_non_alphabets: false,
+            separate_after_non_alphabets: true,
+            separators: "",
+            keep: "",
+        };
+        macro_case_with_options(&self.as_ref(), &opts)
+    }
+
+    fn to_macro_case_with_options(&self, opts: &Options) -> String {
+        macro_case_with_options(&self.as_ref(), opts)
     }
 
     fn to_macro_case_with_nums_as_word(&self) -> String {
-        macro_case_with_nums_as_word(&self.as_ref())
+        let opts = Options {
+            separate_before_non_alphabets: true,
+            separate_after_non_alphabets: true,
+            separators: "",
+            keep: "",
+        };
+        macro_case_with_options(&self.as_ref(), &opts)
     }
 
     fn to_macro_case_with_sep(&self, seps: &str) -> String {
-        macro_case_with_sep(&self.as_ref(), seps)
+        let opts = Options {
+            separate_before_non_alphabets: false,
+            separate_after_non_alphabets: true,
+            separators: seps,
+            keep: "",
+        };
+        macro_case_with_options(&self.as_ref(), &opts)
     }
 
     fn to_macro_case_with_keep(&self, kept: &str) -> String {
-        macro_case_with_keep(&self.as_ref(), kept)
+        let opts = Options {
+            separate_before_non_alphabets: false,
+            separate_after_non_alphabets: true,
+            separators: "",
+            keep: kept,
+        };
+        macro_case_with_options(&self.as_ref(), &opts)
     }
 
     // pascal case
@@ -789,31 +811,52 @@ mod tests_of_caser {
 
     #[test]
     fn it_should_convert_to_macro_case_with_nums_as_word() {
-        let result = "foo_bar100%BAZQux".to_macro_case_with_nums_as_word();
+        let opts = Options {
+            separate_before_non_alphabets: true,
+            separate_after_non_alphabets: true,
+            separators: "",
+            keep: "",
+        };
+
+        let result = "foo_bar100%BAZQux".to_macro_case_with_options(&opts);
         assert_eq!(result, "FOO_BAR_100_BAZ_QUX");
 
         let string = String::from("foo_bar100%BAZQux");
-        let result = string.to_macro_case_with_nums_as_word();
+        let result = string.to_macro_case_with_options(&opts);
         assert_eq!(result, "FOO_BAR_100_BAZ_QUX");
     }
 
     #[test]
     fn it_should_convert_to_macro_case_with_sep() {
-        let result = "foo_bar100%BAZQux".to_macro_case_with_sep("_");
+        let opts = Options {
+            separate_before_non_alphabets: false,
+            separate_after_non_alphabets: true,
+            separators: "_",
+            keep: "",
+        };
+
+        let result = "foo_bar100%BAZQux".to_macro_case_with_options(&opts);
         assert_eq!(result, "FOO_BAR100%_BAZ_QUX");
 
         let string = String::from("foo_bar100%BAZQux");
-        let result = string.to_macro_case_with_sep("_");
+        let result = string.to_macro_case_with_options(&opts);
         assert_eq!(result, "FOO_BAR100%_BAZ_QUX");
     }
 
     #[test]
     fn it_should_convert_to_macro_case_with_keep() {
-        let result = "foo_bar100%BAZQux".to_macro_case_with_keep("%");
+        let opts = Options {
+            separate_before_non_alphabets: false,
+            separate_after_non_alphabets: true,
+            separators: "",
+            keep: "%",
+        };
+
+        let result = "foo_bar100%BAZQux".to_macro_case_with_options(&opts);
         assert_eq!(result, "FOO_BAR100%_BAZ_QUX");
 
         let string = String::from("foo_bar100%BAZQux");
-        let result = string.to_macro_case_with_keep("%");
+        let result = string.to_macro_case_with_options(&opts);
         assert_eq!(result, "FOO_BAR100%_BAZ_QUX");
     }
 

--- a/src/macro_case.rs
+++ b/src/macro_case.rs
@@ -1,321 +1,167 @@
-// Copyright (C) 2024 Takayuki Sato. All Rights Reserved.
+// Copyright (C) 2024-2025 Takayuki Sato. All Rights Reserved.
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
-/// Converts a string to macro case.
-///
-/// This function takes a string slice as its argument, then returns a `String`
-/// of which the case style is macro case.
-///
-/// This function targets the upper and lower cases of ASCII alphabets for
-/// capitalization, and all characters except ASCII alphabets and ASCII numbers
-/// are replaced to underscores as word separators.
+use crate::options::Options;
+
+/// Converts the input string to macro case with the specified options.
 ///
 /// ```rust
-///     let m = stringcase::macro_case("fooBar123Baz");
-///     assert_eq!(m, "FOO_BAR123_BAZ");
+///     let opts = stringcase::Options{
+///       separate_before_non_alphabets: true,
+///       separate_after_non_alphabets: true,
+///       separators: "",
+///       keep: "",
+///     };
+///     let result = stringcase::macro_case_with_options("fooBar123Baz", &opts);
+///     assert_eq!(result, "FOO_BAR_123_BAZ");
+/// ```
+pub fn macro_case_with_options(input: &str, opts: &Options) -> String {
+    let mut result = String::with_capacity(input.len() + input.len() / 2);
+    // .len returns byte count but ok in this case!
+
+    #[derive(PartialEq)]
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfSepMark,
+        NextOfKeptMark,
+        Other,
+    }
+
+    let mut flag = ChIs::FirstOfStr;
+
+    for ch in input.chars() {
+        if ch.is_ascii_uppercase() {
+            if flag == ChIs::FirstOfStr {
+                result.push(ch);
+                flag = ChIs::NextOfUpper;
+            } else if flag == ChIs::NextOfUpper
+                || flag == ChIs::NextOfContdUpper
+                || (!opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
+            {
+                result.push(ch);
+                flag = ChIs::NextOfContdUpper;
+            } else {
+                result.push('_');
+                result.push(ch);
+                flag = ChIs::NextOfUpper;
+            }
+        } else if ch.is_ascii_lowercase() {
+            if flag == ChIs::NextOfContdUpper {
+                if let Some(prev) = result.pop() {
+                    result.push('_');
+                    result.push(prev);
+                    result.push(ch.to_ascii_uppercase());
+                }
+            } else if flag == ChIs::NextOfSepMark
+                || (opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
+            {
+                result.push('_');
+                result.push(ch.to_ascii_uppercase());
+            } else {
+                result.push(ch.to_ascii_uppercase());
+            }
+            flag = ChIs::Other;
+        } else {
+            let mut is_kept_char = false;
+            if ch.is_ascii_digit() {
+                is_kept_char = true;
+            } else if !opts.separators.is_empty() {
+                if !opts.separators.contains(ch) {
+                    is_kept_char = true;
+                }
+            } else if !opts.keep.is_empty() {
+                if opts.keep.contains(ch) {
+                    is_kept_char = true;
+                }
+            }
+
+            if is_kept_char {
+                if opts.separate_before_non_alphabets {
+                    if flag == ChIs::FirstOfStr || flag == ChIs::NextOfKeptMark {
+                        result.push(ch);
+                    } else {
+                        result.push('_');
+                        result.push(ch);
+                    }
+                } else {
+                    if flag != ChIs::NextOfSepMark {
+                        result.push(ch);
+                    } else {
+                        result.push('_');
+                        result.push(ch);
+                    }
+                }
+                flag = ChIs::NextOfKeptMark;
+            } else {
+                if flag != ChIs::FirstOfStr {
+                    flag = ChIs::NextOfSepMark;
+                }
+            }
+        }
+    }
+
+    result
+}
+
+/// Converts the input string to macro case.
+///
+/// It treats the end of a sequence of non-alphabetical characters as a word boundary, but not
+/// the beginning.
+///
+/// ```rust
+///     let result = stringcase::macro_case("fooBar123Baz");
+///     assert_eq!(result, "FOO_BAR123_BAZ");
 /// ```
 pub fn macro_case(input: &str) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
-
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeepedMark,
-        Others,
-    }
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if ch.is_ascii_uppercase() {
-            match flag {
-                ChIs::FirstOfStr => {
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
-                    result.push(ch);
-                    flag = ChIs::NextOfContdUpper;
-                }
-                _ => {
-                    result.push('_');
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-            }
-        } else if ch.is_ascii_lowercase() {
-            match flag {
-                ChIs::NextOfContdUpper => match result.pop() {
-                    Some(prev) => {
-                        result.push('_');
-                        result.push(prev);
-                    }
-                    None => (), // impossible
-                },
-                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
-                    result.push('_');
-                }
-                _ => (),
-            }
-            result.push(ch.to_ascii_uppercase());
-            flag = ChIs::Others;
-        } else if ch.is_ascii_digit() {
-            match flag {
-                ChIs::NextOfSepMark => result.push('_'),
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::NextOfKeepedMark;
-        } else {
-            match flag {
-                ChIs::FirstOfStr => (),
-                _ => flag = ChIs::NextOfSepMark,
-            }
-        }
-    }
-
-    result
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "",
+    };
+    macro_case_with_options(input, &opts)
 }
 
-/// Converts a string to macro case.
-///
-/// This function takes a string slice as its argument, then returns a `String`
-/// of which the case style is macro case.
-///
-/// This function targets the upper and lower cases of ASCII alphabets and ASCII numbers
-/// for capitalization, and all characters except ASCII alphabets and ASCII numbers
-/// are replaced to underscores as word separators.
-///
-/// ```rust
-///     let m = stringcase::macro_case_with_nums_as_word("fooBar123Baz");
-///     assert_eq!(m, "FOO_BAR_123_BAZ");
-/// ```
-pub fn macro_case_with_nums_as_word(input: &str) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
-
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeepedMark, // = next of number
-        Others,
-    }
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if ch.is_ascii_uppercase() {
-            match flag {
-                ChIs::FirstOfStr => {
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
-                    result.push(ch);
-                    flag = ChIs::NextOfContdUpper;
-                }
-                _ => {
-                    result.push('_');
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-            }
-        } else if ch.is_ascii_lowercase() {
-            match flag {
-                ChIs::NextOfContdUpper => match result.pop() {
-                    Some(prev) => {
-                        result.push('_');
-                        result.push(prev);
-                    }
-                    None => (), // impossible
-                },
-                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
-                    result.push('_');
-                }
-                _ => (),
-            }
-            result.push(ch.to_ascii_uppercase());
-            flag = ChIs::Others;
-        } else if ch.is_ascii_digit() {
-            match flag {
-                ChIs::FirstOfStr => (),
-                ChIs::NextOfKeepedMark => (),
-                _ => result.push('_'),
-            }
-            result.push(ch);
-            flag = ChIs::NextOfKeepedMark;
-        } else {
-            match flag {
-                ChIs::FirstOfStr => (),
-                _ => flag = ChIs::NextOfSepMark,
-            }
-        }
-    }
-
-    result
-}
-
-/// Converts a string to macro case using the specified characters as
-/// separators.
-///
-/// This function takes a string slice as its argument, then returns a `String`
-/// of which the case style is macro case.
-///
-/// This function targets only the upper and lower cases of ASCII alphabets for
-/// capitalization, and the characters specified as the second argument of this
-/// function are regarded as word separators and are replaced to underscores.
-///
-/// ```rust
-///     let m = stringcase::macro_case_with_sep("foo-Bar100%Baz", "- ");
-///     assert_eq!(m, "FOO_BAR100%_BAZ");
-/// ```
+/// Converts the input string to macro case with the specified separator characters.
+#[deprecated(since = "0.4.0", note = "Should use macro_case_with_options instead")]
 pub fn macro_case_with_sep(input: &str, seps: &str) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
-
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeepedMark,
-        Others,
-    }
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if seps.contains(ch) {
-            match flag {
-                ChIs::FirstOfStr => (),
-                _ => flag = ChIs::NextOfSepMark,
-            }
-        } else if ch.is_ascii_uppercase() {
-            match flag {
-                ChIs::FirstOfStr => {
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
-                    result.push(ch);
-                    flag = ChIs::NextOfContdUpper;
-                }
-                _ => {
-                    result.push('_');
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-            }
-        } else if ch.is_ascii_lowercase() {
-            match flag {
-                ChIs::NextOfContdUpper => match result.pop() {
-                    Some(prev) => {
-                        result.push('_');
-                        result.push(prev);
-                    }
-                    None => (), // impossible
-                },
-                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
-                    result.push('_');
-                }
-                _ => (),
-            }
-            result.push(ch.to_ascii_uppercase());
-            flag = ChIs::Others;
-        } else {
-            match flag {
-                ChIs::NextOfSepMark => result.push('_'),
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::NextOfKeepedMark;
-        }
-    }
-
-    result
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: seps,
+        keep: "",
+    };
+    macro_case_with_options(input, &opts)
 }
 
-/// Converts a string to macro case using characters other than the specified
-/// characters as separators.
-///
-/// This function takes a string slice as its argument, then returns a `String`
-/// of which the case style is macro case.
-///
-/// This function targets only the upper and lower cases of ASCII alphabets for
-/// capitalization, and the characters other than the specified characters as
-/// the second argument of this function are regarded as word separators and
-/// are replaced to underscores.
-///
-/// ```rust
-///     let m = stringcase::macro_case_with_keep("foo-bar100%baz", "%");
-///     assert_eq!(m, "FOO_BAR100%_BAZ");
-/// ```
-pub fn macro_case_with_keep(input: &str, keeped: &str) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
+/// Converts the input string to macro case with the specified characters to be kept.
+#[deprecated(since = "0.4.0", note = "Should use macro_case_with_options instead")]
+pub fn macro_case_with_keep(input: &str, kept: &str) -> String {
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: kept,
+    };
+    macro_case_with_options(input, &opts)
+}
 
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeepedMark,
-        Others,
-    }
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if ch.is_ascii_uppercase() {
-            match flag {
-                ChIs::FirstOfStr => {
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
-                    result.push(ch);
-                    flag = ChIs::NextOfContdUpper;
-                }
-                _ => {
-                    result.push('_');
-                    result.push(ch);
-                    flag = ChIs::NextOfUpper;
-                }
-            }
-        } else if ch.is_ascii_lowercase() {
-            match flag {
-                ChIs::NextOfContdUpper => match result.pop() {
-                    Some(prev) => {
-                        result.push('_');
-                        result.push(prev);
-                    }
-                    None => (), // impossible
-                },
-                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
-                    result.push('_');
-                }
-                _ => (),
-            }
-            result.push(ch.to_ascii_uppercase());
-            flag = ChIs::Others;
-        } else if ch.is_ascii_digit() || keeped.contains(ch) {
-            match flag {
-                ChIs::NextOfSepMark => result.push('_'),
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::NextOfKeepedMark;
-        } else {
-            match flag {
-                ChIs::FirstOfStr => (),
-                _ => flag = ChIs::NextOfSepMark,
-            }
-        }
-    }
-
-    result
+/// Converts the input string to macro case.
+///
+/// It treats the beginning and the end of a sequence of non-alphabetical characters as a word
+/// boundary.
+#[deprecated(since = "0.4.0", note = "Should use macro_case_with_options instead")]
+pub fn macro_case_with_nums_as_word(input: &str) -> String {
+    let opts = Options {
+        separate_before_non_alphabets: true,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "",
+    };
+    macro_case_with_options(input, &opts)
 }
 
 #[cfg(test)]
@@ -323,365 +169,1975 @@ mod tests_of_macro_case {
     use super::*;
 
     #[test]
-    fn it_should_convert_camel_case() {
+    fn convert_camel_case() {
         let result = macro_case("abcDefGHIjk");
         assert_eq!(result, "ABC_DEF_GH_IJK");
     }
 
     #[test]
-    fn it_should_convert_pascal_case() {
+    fn convert_pascal_case() {
         let result = macro_case("AbcDefGHIjk");
         assert_eq!(result, "ABC_DEF_GH_IJK");
     }
 
     #[test]
-    fn it_should_convert_snake_case() {
+    fn convert_snake_case() {
         let result = macro_case("abc_def_ghi");
         assert_eq!(result, "ABC_DEF_GHI");
     }
 
     #[test]
-    fn it_should_convert_kebab_case() {
+    fn convert_kebab_case() {
         let result = macro_case("abc-def-ghi");
         assert_eq!(result, "ABC_DEF_GHI");
     }
 
     #[test]
-    fn it_should_convert_train_case() {
+    fn convert_train_case() {
         let result = macro_case("Abc-Def-Ghi");
         assert_eq!(result, "ABC_DEF_GHI");
     }
 
     #[test]
-    fn it_should_convert_macro_case() {
+    fn convert_macro_case() {
         let result = macro_case("ABC_DEF_GHI");
         assert_eq!(result, "ABC_DEF_GHI");
     }
 
     #[test]
-    fn it_should_convert_cobol_case() {
+    fn convert_cobol_case() {
         let result = macro_case("ABC-DEF-GHI");
         assert_eq!(result, "ABC_DEF_GHI");
     }
 
     #[test]
-    fn it_should_keep_digits() {
+    fn convert_with_keeping_digits() {
         let result = macro_case("abc123-456defG89HIJklMN12");
         assert_eq!(result, "ABC123_456_DEF_G89_HI_JKL_MN12");
     }
 
     #[test]
-    fn it_should_convert_when_starting_with_digit() {
-        let result = macro_case("123abc456def");
-        assert_eq!(result, "123_ABC456_DEF");
-
-        let result = macro_case("123ABC456DEF");
-        assert_eq!(result, "123_ABC456_DEF");
-    }
-
-    #[test]
-    fn it_should_treat_marks_as_separators() {
+    fn convert_with_symbols_as_separators() {
         let result = macro_case(":.abc~!@def#$ghi%&jk(lm)no/?");
         assert_eq!(result, "ABC_DEF_GHI_JK_LM_NO");
     }
 
     #[test]
-    fn it_should_convert_empty() {
+    fn convert_when_starting_with_digit() {
+        let result = macro_case("123abc456def");
+        assert_eq!(result, "123_ABC456_DEF");
+
+        let result = macro_case("123ABC456DEF");
+        assert_eq!(result, "123_ABC456_DEF");
+
+        let result = macro_case("123Abc456Def");
+        assert_eq!(result, "123_ABC456_DEF");
+    }
+
+    #[test]
+    fn convert_empty_string() {
         let result = macro_case("");
         assert_eq!(result, "");
     }
-
-    #[test]
-    fn it_should_treat_number_sequence_by_default() {
-        let result = macro_case("abc123Def456#Ghi789");
-        assert_eq!(result, "ABC123_DEF456_GHI789");
-
-        let result = macro_case("ABC123-DEF456#GHI789");
-        assert_eq!(result, "ABC123_DEF456_GHI789");
-
-        let result = macro_case("abc123-def456#ghi789");
-        assert_eq!(result, "ABC123_DEF456_GHI789");
-
-        let result = macro_case("ABC123_DEF456#GHI789");
-        assert_eq!(result, "ABC123_DEF456_GHI789");
-
-        let result = macro_case("Abc123Def456#Ghi789");
-        assert_eq!(result, "ABC123_DEF456_GHI789");
-
-        let result = macro_case("abc123_def456#ghi789");
-        assert_eq!(result, "ABC123_DEF456_GHI789");
-
-        let result = macro_case("Abc123-Def456#-Ghi789");
-        assert_eq!(result, "ABC123_DEF456_GHI789");
-
-        let result = macro_case("000-abc123_def456#ghi789");
-        assert_eq!(result, "000_ABC123_DEF456_GHI789");
-    }
 }
 
 #[cfg(test)]
-mod tests_of_macro_case_with_nums_as_word {
+mod tests_of_macro_case_with_options {
     use super::*;
 
-    #[test]
-    fn it_should_convert_camel_case() {
-        let result = macro_case_with_nums_as_word("abcDefGHIjk");
-        assert_eq!(result, "ABC_DEF_GH_IJK");
+    mod non_alphabets_as_head_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_with_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC_123_456DEF_G_89HI_JKL_MN_12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "ABC_DEF_GHI_JK_LM_NO");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123ABC_456DEF");
+
+            let result = macro_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123ABC_456DEF");
+
+            let result = macro_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123_ABC_456_DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_pascal_case() {
-        let result = macro_case_with_nums_as_word("AbcDefGHIjk");
-        assert_eq!(result, "ABC_DEF_GH_IJK");
+    mod non_alphabets_as_tail_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_with_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123_456_DEF_G89_HI_JKL_MN12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "ABC_DEF_GHI_JK_LM_NO");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123_ABC456_DEF");
+
+            let result = macro_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123_ABC456_DEF");
+
+            let result = macro_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123_ABC456_DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_snake_case() {
-        let result = macro_case_with_nums_as_word("abc_def_ghi");
-        assert_eq!(result, "ABC_DEF_GHI");
+    mod non_alphabets_as_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_with_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC_123_456_DEF_G_89_HI_JKL_MN_12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "ABC_DEF_GHI_JK_LM_NO");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123_ABC_456_DEF");
+
+            let result = macro_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123_ABC_456_DEF");
+
+            let result = macro_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123_ABC_456_DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_kebab_case() {
-        let result = macro_case_with_nums_as_word("abc-def-ghi");
-        assert_eq!(result, "ABC_DEF_GHI");
+    mod non_alphabets_as_part_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_with_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123_456DEF_G89HI_JKL_MN12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "ABC_DEF_GHI_JK_LM_NO");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123ABC456DEF");
+
+            let result = macro_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123ABC456DEF");
+
+            let result = macro_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123_ABC456_DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = macro_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_train_case() {
-        let result = macro_case_with_nums_as_word("Abc-Def-Ghi");
-        assert_eq!(result, "ABC_DEF_GHI");
+    mod non_alphabets_as_head_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = macro_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = macro_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "-";
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC__DEF__GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "_";
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC_-DEF_-GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "_";
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC_-_DEF_-_GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "-";
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC__DEF__GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "_";
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC_-DEF_-GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC_123_456DEF_G_89HI_JKL_MN_12");
+
+            opts.separators = "_";
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC_123-456DEF_G_89HI_JKL_MN_12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = macro_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".ABC_~!_DEF_#_GHI_%_JK_LM_NO_?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = macro_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123ABC_456DEF");
+
+            let result = macro_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123ABC_456DEF");
+
+            let result = macro_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123_ABC_456_DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = macro_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_macro_case() {
-        let result = macro_case_with_nums_as_word("ABC_DEF_GHI");
-        assert_eq!(result, "ABC_DEF_GHI");
+    mod non_alphabets_as_tail_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = macro_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = macro_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "-";
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC__DEF__GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "_";
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-_DEF-_GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "_";
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-_DEF-_GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "-";
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC__DEF__GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "_";
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-_DEF-_GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123_456_DEF_G89_HI_JKL_MN12");
+
+            opts.separators = "_";
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123-456_DEF_G89_HI_JKL_MN12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = macro_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "._ABC~!_DEF#_GHI%_JK_LM_NO_?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = macro_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123_ABC456_DEF");
+
+            let result = macro_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123_ABC456_DEF");
+
+            let result = macro_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123_ABC456_DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = macro_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_cobol_case() {
-        let result = macro_case_with_nums_as_word("ABC-DEF-GHI");
-        assert_eq!(result, "ABC_DEF_GHI");
+    mod non_alphabets_as_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = macro_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = macro_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "-";
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC___DEF___GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "_";
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC_-_DEF_-_GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "_";
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC_-_DEF_-_GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "-";
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC___DEF___GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "_";
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC_-_DEF_-_GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC_123_456_DEF_G_89_HI_JKL_MN_12");
+
+            opts.separators = "_";
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC_123-456_DEF_G_89_HI_JKL_MN_12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = macro_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "._ABC_~!_DEF_#_GHI_%_JK_LM_NO_?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = macro_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123_ABC_456_DEF");
+
+            let result = macro_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123_ABC_456_DEF");
+
+            let result = macro_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123_ABC_456_DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = macro_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_keep_digits() {
-        let result = macro_case_with_nums_as_word("abc123-456defG89HIJklMN12");
-        assert_eq!(result, "ABC_123_456_DEF_G_89_HI_JKL_MN_12");
+    mod non_alphabets_as_part_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = macro_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = macro_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "-";
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "_";
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "_";
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-_DEF-_GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "-";
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.separators = "_";
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123_456DEF_G89HI_JKL_MN12");
+
+            opts.separators = "_";
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123-456DEF_G89HI_JKL_MN12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = macro_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".ABC~!_DEF#_GHI%_JK_LM_NO_?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = macro_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123ABC456DEF");
+
+            let result = macro_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123ABC456DEF");
+
+            let result = macro_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123_ABC456_DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = macro_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_when_starting_with_digit() {
-        let result = macro_case_with_nums_as_word("123abc456def");
-        assert_eq!(result, "123_ABC_456_DEF");
+    mod non_alphabets_as_head_of_a_word_with_kept_characters {
+        use super::*;
 
-        let result = macro_case_with_nums_as_word("123ABC456DEF");
-        assert_eq!(result, "123_ABC_456_DEF");
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = macro_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = macro_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC__DEF__GHI");
+
+            opts.keep = "-";
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.keep = "-";
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC_-DEF_-GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.keep = "-";
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC_-_DEF_-_GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.keep = "_";
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC__DEF__GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.keep = "-";
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC_-DEF_-GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC_123_456DEF_G_89HI_JKL_MN_12");
+
+            opts.keep = "-";
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC_123-456DEF_G_89HI_JKL_MN_12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: ".~!#%?",
+            };
+            let result = macro_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".ABC_~!_DEF_#_GHI_%_JK_LM_NO_?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = macro_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123ABC_456DEF");
+
+            let result = macro_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123ABC_456DEF");
+
+            let result = macro_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123_ABC_456_DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = macro_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_treat_marks_as_separators() {
-        let result = macro_case_with_nums_as_word(":.abc~!@def#$ghi%&jk(lm)no/?");
-        assert_eq!(result, "ABC_DEF_GHI_JK_LM_NO");
+    mod non_alphabets_as_tail_of_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = macro_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = macro_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.keep = "_";
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC__DEF__GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.keep = "-";
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-_DEF-_GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.keep = "-";
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-_DEF-_GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.keep = "_";
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC__DEF__GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.keep = "-";
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-_DEF-_GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123_456_DEF_G89_HI_JKL_MN12");
+
+            opts.keep = "-";
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123-456_DEF_G89_HI_JKL_MN12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: ".~!#%?",
+            };
+            let result = macro_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "._ABC~!_DEF#_GHI%_JK_LM_NO_?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = macro_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123_ABC456_DEF");
+
+            let result = macro_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123_ABC456_DEF");
+
+            let result = macro_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123_ABC456_DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = macro_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_empty() {
-        let result = macro_case_with_nums_as_word("");
-        assert_eq!(result, "");
+    mod non_alphabets_as_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = macro_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = macro_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.keep = "_";
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC___DEF___GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.keep = "-";
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC_-_DEF_-_GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.keep = "-";
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC_-_DEF_-_GHI");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.keep = "_";
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC___DEF___GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+
+            opts.keep = "-";
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC_-_DEF_-_GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC_123_456_DEF_G_89_HI_JKL_MN_12");
+
+            opts.keep = "-";
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC_123-456_DEF_G_89_HI_JKL_MN_12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: ".~!#%?",
+            };
+            let result = macro_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "._ABC_~!_DEF_#_GHI_%_JK_LM_NO_?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = macro_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123_ABC_456_DEF");
+
+            let result = macro_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123_ABC_456_DEF");
+
+            let result = macro_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123_ABC_456_DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = macro_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_treat_number_sequence_as_word() {
-        let result = macro_case_with_nums_as_word("abc123Def456#Ghi789");
-        assert_eq!(result, "ABC_123_DEF_456_GHI_789");
+    mod non_alphabets_as_part_of_a_word_with_kept_characters {
+        use super::*;
 
-        let result = macro_case_with_nums_as_word("ABC123-DEF456#GHI789");
-        assert_eq!(result, "ABC_123_DEF_456_GHI_789");
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = macro_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
 
-        let result = macro_case_with_nums_as_word("abc123-def456#ghi789");
-        assert_eq!(result, "ABC_123_DEF_456_GHI_789");
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = macro_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC_DEF_GH_IJK");
+        }
 
-        let result = macro_case_with_nums_as_word("ABC123_DEF456#GHI789");
-        assert_eq!(result, "ABC_123_DEF_456_GHI_789");
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
 
-        let result = macro_case_with_nums_as_word("Abc123Def456#Ghi789");
-        assert_eq!(result, "ABC_123_DEF_456_GHI_789");
+            opts.keep = "_";
+            let result = macro_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
 
-        let result = macro_case_with_nums_as_word("abc123_def456#ghi789");
-        assert_eq!(result, "ABC_123_DEF_456_GHI_789");
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
 
-        let result = macro_case_with_nums_as_word("Abc123-Def456#-Ghi789");
-        assert_eq!(result, "ABC_123_DEF_456_GHI_789");
+            opts.keep = "-";
+            let result = macro_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
 
-        let result = macro_case_with_nums_as_word("000-abc123_def456#ghi789");
-        assert_eq!(result, "000_ABC_123_DEF_456_GHI_789");
-    }
-}
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
 
-#[cfg(test)]
-mod tests_of_macro_case_with_sep {
-    use super::*;
+            opts.keep = "-";
+            let result = macro_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-_DEF-_GHI");
+        }
 
-    #[test]
-    fn it_should_convert_camel_case() {
-        let result = macro_case_with_sep("abcDefGHIjk", "-_");
-        assert_eq!(result, "ABC_DEF_GH_IJK");
-    }
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
 
-    #[test]
-    fn it_should_convert_pascal_case() {
-        let result = macro_case_with_sep("AbcDefGHIjk", "-_");
-        assert_eq!(result, "ABC_DEF_GH_IJK");
-    }
+            opts.keep = "_";
+            let result = macro_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
 
-    #[test]
-    fn it_should_convert_kebab_case() {
-        let result = macro_case_with_sep("abc-def-ghi", "-");
-        assert_eq!(result, "ABC_DEF_GHI");
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
 
-        let result = macro_case_with_sep("abc-def-ghi", "_");
-        assert_eq!(result, "ABC-_DEF-_GHI");
-    }
+            opts.keep = "-";
+            let result = macro_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
 
-    #[test]
-    fn it_should_convert_train_case() {
-        let result = macro_case_with_sep("Abc-Def-Ghi", "-");
-        assert_eq!(result, "ABC_DEF_GHI");
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123_456DEF_G89HI_JKL_MN12");
 
-        let result = macro_case_with_sep("Abc-Def-Ghi", "_");
-        assert_eq!(result, "ABC-_DEF-_GHI");
-    }
+            opts.keep = "-";
+            let result = macro_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123-456DEF_G89HI_JKL_MN12");
+        }
 
-    #[test]
-    fn it_should_convert_macro_case() {
-        let result = macro_case_with_sep("ABC_DEF_GHI", "_");
-        assert_eq!(result, "ABC_DEF_GHI");
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: ".~!#%?",
+            };
+            let result = macro_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".ABC~!_DEF#_GHI%_JK_LM_NO_?");
+        }
 
-        let result = macro_case_with_sep("ABC_DEF_GHI", "-");
-        assert_eq!(result, "ABC__DEF__GHI");
-    }
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = macro_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123ABC456DEF");
 
-    #[test]
-    fn it_should_convert_cobol_case() {
-        let result = macro_case_with_sep("ABC-DEF-GHI", "-");
-        assert_eq!(result, "ABC_DEF_GHI");
+            let result = macro_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123ABC456DEF");
 
-        let result = macro_case_with_sep("ABC-DEF-GHI", "_");
-        assert_eq!(result, "ABC-_DEF-_GHI");
-    }
+            let result = macro_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123_ABC456_DEF");
+        }
 
-    #[test]
-    fn it_should_keep_digits() {
-        let result = macro_case_with_sep("abc123-456defG89HIJklMN12", "-");
-        assert_eq!(result, "ABC123_456_DEF_G89_HI_JKL_MN12");
-
-        let result = macro_case_with_sep("abc123-456defG89HIJklMN12", "_");
-        assert_eq!(result, "ABC123-456_DEF_G89_HI_JKL_MN12");
-    }
-
-    #[test]
-    fn it_should_convert_when_starting_with_digit() {
-        let result = macro_case_with_sep("123abc456def", "_");
-        assert_eq!(result, "123_ABC456_DEF");
-
-        let result = macro_case_with_sep("123ABC456DEF", "_");
-        assert_eq!(result, "123_ABC456_DEF");
-    }
-
-    #[test]
-    fn it_should_treat_marks_as_separators() {
-        let result = macro_case_with_sep(":.abc~!@def#$ghi%&jk(lm)no/?", ":@$&()/");
-        assert_eq!(result, "._ABC~!_DEF#_GHI%_JK_LM_NO_?");
-    }
-
-    #[test]
-    fn it_should_convert_empty() {
-        let result = macro_case_with_sep("", "_-");
-        assert_eq!(result, "");
-    }
-}
-
-#[cfg(test)]
-mod tests_of_macro_case_with_keep {
-    use super::*;
-
-    #[test]
-    fn it_should_convert_camel_case() {
-        let result = macro_case_with_keep("abcDefGHIjk", "-_");
-        assert_eq!(result, "ABC_DEF_GH_IJK");
-    }
-
-    #[test]
-    fn it_should_convert_pascal_case() {
-        let result = macro_case_with_keep("AbcDefGHIjk", "-_");
-        assert_eq!(result, "ABC_DEF_GH_IJK");
-    }
-
-    #[test]
-    fn it_should_convert_kebab_case() {
-        let result = macro_case_with_keep("abc-def-ghi", "_");
-        assert_eq!(result, "ABC_DEF_GHI");
-
-        let result = macro_case_with_keep("abc-def-ghi", "-");
-        assert_eq!(result, "ABC-_DEF-_GHI");
-    }
-
-    #[test]
-    fn it_should_convert_train_case() {
-        let result = macro_case_with_keep("Abc-Def-Ghi", "_");
-        assert_eq!(result, "ABC_DEF_GHI");
-
-        let result = macro_case_with_keep("Abc-Def-Ghi", "-");
-        assert_eq!(result, "ABC-_DEF-_GHI");
-    }
-
-    #[test]
-    fn it_should_convert_macro_case() {
-        let result = macro_case_with_keep("ABC_DEF_GHI", "-");
-        assert_eq!(result, "ABC_DEF_GHI");
-
-        let result = macro_case_with_keep("ABC_DEF_GHI", "_");
-        assert_eq!(result, "ABC__DEF__GHI");
-    }
-
-    #[test]
-    fn it_should_convert_cobol_case() {
-        let result = macro_case_with_keep("ABC-DEF-GHI", "_");
-        assert_eq!(result, "ABC_DEF_GHI");
-
-        let result = macro_case_with_keep("ABC-DEF-GHI", "-");
-        assert_eq!(result, "ABC-_DEF-_GHI");
-    }
-
-    #[test]
-    fn it_should_keep_digits() {
-        let result = macro_case_with_keep("abc123-456defG89HIJklMN12", "_");
-        assert_eq!(result, "ABC123_456_DEF_G89_HI_JKL_MN12");
-
-        let result = macro_case_with_keep("abc123-456defG89HIJklMN12", "-");
-        assert_eq!(result, "ABC123-456_DEF_G89_HI_JKL_MN12");
-    }
-
-    #[test]
-    fn it_should_convert_when_starting_with_digit() {
-        let result = macro_case_with_keep("123abc456def", "_");
-        assert_eq!(result, "123_ABC456_DEF");
-
-        let result = macro_case_with_keep("123ABC456DEF", "_");
-        assert_eq!(result, "123_ABC456_DEF");
-    }
-
-    #[test]
-    fn it_should_treat_marks_as_separators() {
-        let result = macro_case_with_keep(":.abc~!@def#$ghi%&jk(lm)no/?", ".~!#%?");
-        assert_eq!(result, "._ABC~!_DEF#_GHI%_JK_LM_NO_?");
-    }
-
-    #[test]
-    fn it_should_convert_empty() {
-        let result = macro_case_with_sep("", "_-");
-        assert_eq!(result, "");
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = macro_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 }

--- a/tests/caser_test.rs
+++ b/tests/caser_test.rs
@@ -122,19 +122,37 @@ fn it_should_convert_to_macro_case_by_method_of_string() {
 
 #[test]
 fn it_should_convert_to_macro_case_with_nums_as_word_by_method_of_string() {
-    let converted = "foo_bar100BAZQux".to_macro_case_with_nums_as_word();
+    let opts = Options {
+        separate_before_non_alphabets: true,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "",
+    };
+    let converted = "foo_bar100BAZQux".to_macro_case_with_options(&opts);
     assert_eq!(converted, "FOO_BAR_100_BAZ_QUX");
 }
 
 #[test]
 fn it_should_convert_to_macro_case_with_sep_by_method_of_string() {
-    let converted = "foo_bar100BAZQux".to_macro_case_with_sep("_");
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "_",
+        keep: "",
+    };
+    let converted = "foo_bar100BAZQux".to_macro_case_with_options(&opts);
     assert_eq!(converted, "FOO_BAR100_BAZ_QUX");
 }
 
 #[test]
 fn it_should_convert_to_macro_case_with_keep_by_method_of_string() {
-    let converted = "foo_bar100BAZQux".to_macro_case_with_keep("#");
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "#",
+    };
+    let converted = "foo_bar100BAZQux".to_macro_case_with_options(&opts);
     assert_eq!(converted, "FOO_BAR100_BAZ_QUX");
 }
 

--- a/tests/macro_case_test.rs
+++ b/tests/macro_case_test.rs
@@ -1,4 +1,4 @@
-use stringcase::{macro_case, macro_case_with_keep, macro_case_with_sep};
+use stringcase::{macro_case, macro_case_with_options, Options};
 
 #[test]
 fn it_should_convert_to_macro_case() {
@@ -8,20 +8,38 @@ fn it_should_convert_to_macro_case() {
 
 #[test]
 fn it_should_convert_to_macro_case_with_sep() {
-    let converted = macro_case_with_sep("foo_bar100%BAZQux", "_");
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "_",
+        keep: "",
+    };
+    let converted = macro_case_with_options("foo_bar100%BAZQux", &opts);
     assert_eq!(converted, "FOO_BAR100%_BAZ_QUX");
 }
 
 #[test]
 fn it_should_convert_to_macro_case_with_keep() {
-    let converted = macro_case_with_keep("foo_bar100%BAZQux", "%");
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "%",
+    };
+
+    let converted = macro_case_with_options("foo_bar100%BAZQux", &opts);
     assert_eq!(converted, "FOO_BAR100%_BAZ_QUX");
 }
 
 #[test]
 fn it_should_convert_to_macro_case_with_nums_as_word() {
-    use stringcase::macro_case_with_nums_as_word as macro_case;
+    let opts = Options {
+        separate_before_non_alphabets: true,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "",
+    };
 
-    let converted = macro_case("foo-bar100%-baz-qux");
+    let converted = macro_case_with_options("foo-bar100%-baz-qux", &opts);
     assert_eq!(converted, "FOO_BAR_100_BAZ_QUX");
 }


### PR DESCRIPTION
(Related to #24)

This PR adds the new function `macro_case_with_options`, which supports handling non alphabetical characters, separators, and kept characters with `Options`.

`macro_case` is changed to use this function inside, and `macro_case_with_nums_as_word`,  `macro_case_with_sep` and `macro_case_with_keep` are deprecated.