### PR TITLE
new!: added snake_case_with_options and made use it in existing snake case functions

### DIFF
--- a/src/snake_case.rs
+++ b/src/snake_case.rs
@@ -1,321 +1,167 @@
-// Copyright (C) 2024 Takayuki Sato. All Rights Reserved.
+// Copyright (C) 2024-2025 Takayuki Sato. All Rights Reserved.
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
-/// Converts a string to snake case.
+use crate::options::Options;
+
+/// Converts the input string to snake case with the specified options.
 ///
-/// This function takes a string slice as its argument, then returns a `String`
-/// of which the case style is snake case.
+/// ```rust
+///     let opts = stringcase::Options{
+///       separate_before_non_alphabets: true,
+///       separate_after_non_alphabets: true,
+///       separators: "",
+///       keep: "",
+///     };
+///     let snake = stringcase::snake_case_with_options("fooBar123Baz", &opts);
+///     assert_eq!(snake, "foo_bar_123_baz");
+/// ```
+pub fn snake_case_with_options(input: &str, opts: &Options) -> String {
+    let mut result = String::with_capacity(input.len() + input.len() / 2);
+    // .len returns byte count but ok in this case!
+
+    #[derive(PartialEq)]
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfSepMark,
+        NextOfKeptMark,
+        Other,
+    }
+
+    let mut flag = ChIs::FirstOfStr;
+
+    for ch in input.chars() {
+        if ch.is_ascii_uppercase() {
+            if flag == ChIs::FirstOfStr {
+                result.push(ch.to_ascii_lowercase());
+                flag = ChIs::NextOfUpper;
+            } else if flag == ChIs::NextOfUpper
+                || flag == ChIs::NextOfContdUpper
+                || (!opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
+            {
+                result.push(ch.to_ascii_lowercase());
+                flag = ChIs::NextOfContdUpper;
+            } else {
+                result.push('_');
+                result.push(ch.to_ascii_lowercase());
+                flag = ChIs::NextOfUpper;
+            }
+        } else if ch.is_ascii_lowercase() {
+            if flag == ChIs::NextOfContdUpper {
+                if let Some(prev) = result.pop() {
+                    result.push('_');
+                    result.push(prev);
+                    result.push(ch);
+                }
+            } else if flag == ChIs::NextOfSepMark
+                || (opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
+            {
+                result.push('_');
+                result.push(ch);
+            } else {
+                result.push(ch);
+            }
+            flag = ChIs::Other;
+        } else {
+            let mut is_kept_char = false;
+            if ch.is_ascii_digit() {
+                is_kept_char = true;
+            } else if !opts.separators.is_empty() {
+                if !opts.separators.contains(ch) {
+                    is_kept_char = true;
+                }
+            } else if !opts.keep.is_empty() {
+                if opts.keep.contains(ch) {
+                    is_kept_char = true;
+                }
+            }
+
+            if is_kept_char {
+                if opts.separate_before_non_alphabets {
+                    if flag == ChIs::FirstOfStr || flag == ChIs::NextOfKeptMark {
+                        result.push(ch);
+                    } else {
+                        result.push('_');
+                        result.push(ch);
+                    }
+                } else {
+                    if flag != ChIs::NextOfSepMark {
+                        result.push(ch);
+                    } else {
+                        result.push('_');
+                        result.push(ch);
+                    }
+                }
+                flag = ChIs::NextOfKeptMark;
+            } else {
+                if flag != ChIs::FirstOfStr {
+                    flag = ChIs::NextOfSepMark;
+                }
+            }
+        }
+    }
+
+    result
+}
+
+/// Converts the input string to snake case.
 ///
-/// This function targets the upper and lower cases of ASCII alphabets for
-/// capitalization, and all characters except ASCII alphabets and ASCII numbers
-/// are replaced to underscores as word separators.
+/// It treats the end of a sequence of non-alphabetical characters as a word boundary, but not
+/// the beginning.
 ///
 /// ```rust
 ///     let snake = stringcase::snake_case("fooBar123Baz");
 ///     assert_eq!(snake, "foo_bar123_baz");
 /// ```
 pub fn snake_case(input: &str) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
-
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeepedMark,
-        Others,
-    }
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if ch.is_ascii_uppercase() {
-            match flag {
-                ChIs::FirstOfStr => {
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfUpper;
-                }
-                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfContdUpper;
-                }
-                _ => {
-                    result.push('_');
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfUpper;
-                }
-            }
-        } else if ch.is_ascii_lowercase() {
-            match flag {
-                ChIs::NextOfContdUpper => match result.pop() {
-                    Some(prev) => {
-                        result.push('_');
-                        result.push(prev);
-                    }
-                    None => (), // impossible
-                },
-                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
-                    result.push('_');
-                }
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::Others;
-        } else if ch.is_ascii_digit() {
-            match flag {
-                ChIs::NextOfSepMark => result.push('_'),
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::NextOfKeepedMark;
-        } else {
-            match flag {
-                ChIs::FirstOfStr => (),
-                _ => flag = ChIs::NextOfSepMark,
-            }
-        }
-    }
-
-    result
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "",
+    };
+    snake_case_with_options(input, &opts)
 }
 
-/// Converts a string to snake case.
-///
-/// This function takes a string slice as its argument, then returns a `String`
-/// of which the case style is snake case.
-///
-/// This function targets the upper and lower cases of ASCII alphabets and ASCII numbers
-/// for capitalization, and all characters except ASCII alphabets and ASCII numbers
-/// are replaced to underscores as word separators.
-///
-/// ```rust
-///     let snake = stringcase::snake_case_with_nums_as_word("fooBar123Baz");
-///     assert_eq!(snake, "foo_bar_123_baz");
-/// ```
-pub fn snake_case_with_nums_as_word(input: &str) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
-
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeepedMark, // = next of number
-        Others,
-    }
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if ch.is_ascii_uppercase() {
-            match flag {
-                ChIs::FirstOfStr => {
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfUpper;
-                }
-                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfContdUpper;
-                }
-                _ => {
-                    result.push('_');
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfUpper;
-                }
-            }
-        } else if ch.is_ascii_lowercase() {
-            match flag {
-                ChIs::NextOfContdUpper => match result.pop() {
-                    Some(prev) => {
-                        result.push('_');
-                        result.push(prev);
-                    }
-                    None => (), // impossible
-                },
-                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
-                    result.push('_');
-                }
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::Others;
-        } else if ch.is_ascii_digit() {
-            match flag {
-                ChIs::FirstOfStr => (),
-                ChIs::NextOfKeepedMark => (),
-                _ => result.push('_'),
-            }
-            result.push(ch);
-            flag = ChIs::NextOfKeepedMark;
-        } else {
-            match flag {
-                ChIs::FirstOfStr => (),
-                _ => flag = ChIs::NextOfSepMark,
-            }
-        }
-    }
-
-    result
-}
-
-/// Converts a string to snake case using the specified characters as
-/// separators.
-///
-/// This function takes a string slice as its argument, then returns a `String`
-/// of which the case style is snake case.
-///
-/// This function targets only the upper and lower cases of ASCII alphabets for
-/// capitalization, and the characters specified as the second argument of this
-/// function are regarded as word separators and are replaced to underscores.
-///
-/// ```rust
-///     let snake = stringcase::snake_case_with_sep("foo-Bar100%Baz", "- ");
-///     assert_eq!(snake, "foo_bar100%_baz");
-/// ```
+/// Converts the input string to snake case with the specified separator characters.
+#[deprecated(since = "0.4.0", note = "Should use snake_case_with_options instead")]
 pub fn snake_case_with_sep(input: &str, seps: &str) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
-
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeepedMark,
-        Others,
-    }
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if seps.contains(ch) {
-            match flag {
-                ChIs::FirstOfStr => (),
-                _ => flag = ChIs::NextOfSepMark,
-            }
-        } else if ch.is_ascii_uppercase() {
-            match flag {
-                ChIs::FirstOfStr => {
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfUpper;
-                }
-                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfContdUpper;
-                }
-                _ => {
-                    result.push('_');
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfUpper;
-                }
-            }
-        } else if ch.is_ascii_lowercase() {
-            match flag {
-                ChIs::NextOfContdUpper => match result.pop() {
-                    Some(prev) => {
-                        result.push('_');
-                        result.push(prev);
-                    }
-                    None => (), // impossible
-                },
-                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
-                    result.push('_');
-                }
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::Others;
-        } else {
-            match flag {
-                ChIs::NextOfSepMark => result.push('_'),
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::NextOfKeepedMark;
-        }
-    }
-
-    result
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: seps,
+        keep: "",
+    };
+    snake_case_with_options(input, &opts)
 }
 
-/// Converts a string to snake case using characters other than the specified
-/// characters as separators.
-///
-/// This function takes a string slice as its argument, then returns a `String`
-/// of which the case style is snake case.
-///
-/// This function targets only the upper and lower cases of ASCII alphabets for
-/// capitalization, and the characters other than the specified characters as
-/// the second argument of this function are regarded as word separators and
-/// are replaced to underscores.
-///
-/// ```rust
-///     let snake = stringcase::snake_case_with_keep("foo-bar100%baz", "%");
-///     assert_eq!(snake, "foo_bar100%_baz");
-/// ```
-pub fn snake_case_with_keep(input: &str, keeped: &str) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
+/// Converts the input string to snake case with the specified characters to be kept.
+#[deprecated(since = "0.4.0", note = "Should use snake_case_with_options instead")]
+pub fn snake_case_with_keep(input: &str, kept: &str) -> String {
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: kept,
+    };
+    snake_case_with_options(input, &opts)
+}
 
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeepedMark,
-        Others,
-    }
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if ch.is_ascii_uppercase() {
-            match flag {
-                ChIs::FirstOfStr => {
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfUpper;
-                }
-                ChIs::NextOfUpper | ChIs::NextOfContdUpper => {
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfContdUpper;
-                }
-                _ => {
-                    result.push('_');
-                    result.push(ch.to_ascii_lowercase());
-                    flag = ChIs::NextOfUpper;
-                }
-            }
-        } else if ch.is_ascii_lowercase() {
-            match flag {
-                ChIs::NextOfContdUpper => match result.pop() {
-                    Some(prev) => {
-                        result.push('_');
-                        result.push(prev);
-                    }
-                    None => (), // impossible
-                },
-                ChIs::NextOfSepMark | ChIs::NextOfKeepedMark => {
-                    result.push('_');
-                }
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::Others;
-        } else if ch.is_ascii_digit() || keeped.contains(ch) {
-            match flag {
-                ChIs::NextOfSepMark => result.push('_'),
-                _ => (),
-            }
-            result.push(ch);
-            flag = ChIs::NextOfKeepedMark;
-        } else {
-            match flag {
-                ChIs::FirstOfStr => (),
-                _ => flag = ChIs::NextOfSepMark,
-            }
-        }
-    }
-
-    result
+/// Converts the input string to snake case.
+///
+/// It treats the beginning and the end of a sequence of non-alphabetical characters as a word
+/// boundary.
+#[deprecated(since = "0.4.0", note = "Should use snake_case_with_options instead")]
+pub fn snake_case_with_nums_as_word(input: &str) -> String {
+    let opts = Options {
+        separate_before_non_alphabets: true,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "",
+    };
+    snake_case_with_options(input, &opts)
 }
 
 #[cfg(test)]
@@ -323,311 +169,1999 @@ mod tests_of_snake_case {
     use super::*;
 
     #[test]
-    fn it_should_convert_camel_case() {
+    fn convert_camel_case() {
         let result = snake_case("abcDefGHIjk");
         assert_eq!(result, "abc_def_gh_ijk");
     }
 
     #[test]
-    fn it_should_convert_pascal_case() {
+    fn convert_pascal_case() {
         let result = snake_case("AbcDefGHIjk");
         assert_eq!(result, "abc_def_gh_ijk");
     }
 
     #[test]
-    fn it_should_convert_snake_case() {
+    fn convert_snake_case() {
         let result = snake_case("abc_def_ghi");
         assert_eq!(result, "abc_def_ghi");
     }
 
     #[test]
-    fn it_should_convert_kebab_case() {
+    fn convert_kebab_case() {
         let result = snake_case("abc-def-ghi");
         assert_eq!(result, "abc_def_ghi");
     }
 
     #[test]
-    fn it_should_convert_train_case() {
+    fn convert_train_case() {
         let result = snake_case("Abc-Def-Ghi");
         assert_eq!(result, "abc_def_ghi");
     }
 
     #[test]
-    fn it_should_convert_macro_case() {
+    fn convert_macro_case() {
         let result = snake_case("ABC_DEF_GHI");
         assert_eq!(result, "abc_def_ghi");
     }
 
     #[test]
-    fn it_should_convert_cobol_case() {
+    fn convert_cobol_case() {
         let result = snake_case("ABC-DEF-GHI");
         assert_eq!(result, "abc_def_ghi");
     }
 
     #[test]
-    fn it_should_keep_digits() {
-        let result = snake_case("abc123-456defG789HIJklMN12");
-        assert_eq!(result, "abc123_456_def_g789_hi_jkl_mn12");
+    fn convert_with_keeping_digits() {
+        let result = snake_case("abc123-456defG89HIJklMN12");
+        assert_eq!(result, "abc123_456_def_g89_hi_jkl_mn12");
     }
 
     #[test]
-    fn it_should_convert_when_starting_with_digit() {
-        let result = snake_case("123abc456def");
-        assert_eq!(result, "123_abc456_def");
-
-        let result = snake_case("123ABC456DEF");
-        assert_eq!(result, "123_abc456_def");
-    }
-
-    #[test]
-    fn it_should_treat_marks_as_separators() {
+    fn convert_with_symbols_as_separators() {
         let result = snake_case(":.abc~!@def#$ghi%&jk(lm)no/?");
         assert_eq!(result, "abc_def_ghi_jk_lm_no");
     }
 
     #[test]
-    fn it_should_convert_empty() {
+    fn convert_when_starting_with_digit() {
+        let result = snake_case("123abc456def");
+        assert_eq!(result, "123_abc456_def");
+
+        let result = snake_case("123ABC456DEF");
+        assert_eq!(result, "123_abc456_def");
+
+        let result = snake_case("123Abc456Def");
+        assert_eq!(result, "123_abc456_def");
+    }
+
+    #[test]
+    fn convert_empty_string() {
         let result = snake_case("");
         assert_eq!(result, "");
     }
 }
 
 #[cfg(test)]
-mod tests_of_snake_case_with_nums_as_word {
+mod tests_of_cobol_case_with_options {
     use super::*;
 
-    #[test]
-    fn it_should_convert_camel_case() {
-        let result = snake_case_with_nums_as_word("abcDefGHIjk");
-        assert_eq!(result, "abc_def_gh_ijk");
+    mod non_alphabets_as_head_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc_123_456def_g_89hi_jkl_mn_12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "abc_def_ghi_jk_lm_no");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123abc_456def");
+
+            let result = snake_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc_456def");
+
+            let result = snake_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123_abc_456_def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_pascal_case() {
-        let result = snake_case_with_nums_as_word("AbcDefGHIjk");
-        assert_eq!(result, "abc_def_gh_ijk");
+    mod non_alphabets_as_tail_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123_456_def_g89_hi_jkl_mn12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "abc_def_ghi_jk_lm_no");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123_abc456_def");
+
+            let result = snake_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123_abc456_def");
+
+            let result = snake_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123_abc456_def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_snake_case() {
-        let result = snake_case_with_nums_as_word("abc_def_ghi");
-        assert_eq!(result, "abc_def_ghi");
+    mod non_alphabets_as_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc_123_456_def_g_89_hi_jkl_mn_12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "abc_def_ghi_jk_lm_no");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123_abc_456_def");
+
+            let result = snake_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123_abc_456_def");
+
+            let result = snake_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123_abc_456_def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_kebab_case() {
-        let result = snake_case_with_nums_as_word("abc-def-ghi");
-        assert_eq!(result, "abc_def_ghi");
+    mod non_alphabets_as_part_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123_456def_g89hi_jkl_mn12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "abc_def_ghi_jk_lm_no");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123abc456def");
+
+            let result = snake_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc456def");
+
+            let result = snake_case_with_options("123Abc456Def", &opts);
+            assert_eq!(result, "123_abc456_def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = snake_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_train_case() {
-        let result = snake_case_with_nums_as_word("Abc-Def-Ghi");
-        assert_eq!(result, "abc_def_ghi");
+    mod non_alphabets_as_head_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = snake_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = snake_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "-";
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc__def__ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "_";
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc_-def_-ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "_";
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc_-_def_-_ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "-";
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc__def__ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "_";
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc_-def_-ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc_123_456def_g_89hi_jkl_mn_12");
+
+            opts.separators = "_";
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc_123-456def_g_89hi_jkl_mn_12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = snake_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".abc_~!_def_#_ghi_%_jk_lm_no_?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123abc_456def");
+
+            let result = snake_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc_456def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = snake_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
+
+        #[test]
+        fn alphabets_and_numbers_in_separators_have_no_effect() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-b2",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc123def", &opts);
+            assert_eq!(result, "abc_123def");
+        }
     }
 
-    #[test]
-    fn it_should_convert_macro_case() {
-        let result = snake_case_with_nums_as_word("ABC_DEF_GHI");
-        assert_eq!(result, "abc_def_ghi");
+    mod non_alphabets_as_tail_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = snake_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = snake_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "-";
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc__def__ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "_";
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-_def-_ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "_";
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-_def-_ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "-";
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc__def__ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "_";
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-_def-_ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123_456_def_g89_hi_jkl_mn12");
+
+            opts.separators = "_";
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123-456_def_g89_hi_jkl_mn12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = snake_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "._abc~!_def#_ghi%_jk_lm_no_?");
+        }
+
+        #[test]
+        fn convert_with_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123_abc456_def");
+
+            let result = snake_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123_abc456_def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = snake_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
+
+        #[test]
+        fn alphabets_and_numbers_in_separators_no_effect() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-b2",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc123def", &opts);
+            assert_eq!(result, "abc123_def");
+        }
     }
 
-    #[test]
-    fn it_should_convert_cobol_case() {
-        let result = snake_case_with_nums_as_word("ABC-DEF-GHI");
-        assert_eq!(result, "abc_def_ghi");
+    mod non_alphabets_as_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = snake_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = snake_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "-";
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc___def___ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "_";
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc_-_def_-_ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "_";
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc_-_def_-_ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "-";
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc___def___ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "_";
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc_-_def_-_ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc_123_456_def_g_89_hi_jkl_mn_12");
+
+            opts.separators = "_";
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc_123-456_def_g_89_hi_jkl_mn_12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = snake_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "._abc_~!_def_#_ghi_%_jk_lm_no_?");
+        }
+
+        #[test]
+        fn convert_with_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123_abc_456_def");
+
+            let result = snake_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123_abc_456_def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = snake_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
+
+        #[test]
+        fn alphabets_and_numbers_in_separators_have_no_effect() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-b2",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc123def", &opts);
+            assert_eq!(result, "abc_123_def");
+        }
     }
 
-    #[test]
-    fn it_should_keep_digits() {
-        let result = snake_case_with_nums_as_word("abc123-456defG789HIJklMN12");
-        assert_eq!(result, "abc_123_456_def_g_789_hi_jkl_mn_12");
+    mod non_alphabets_as_part_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = snake_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = snake_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "-";
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "_";
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "_";
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-_def-_ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "-";
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.separators = "_";
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123_456def_g89hi_jkl_mn12");
+
+            opts.separators = "_";
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123-456def_g89hi_jkl_mn12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = snake_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".abc~!_def#_ghi%_jk_lm_no_?");
+        }
+
+        #[test]
+        fn convert_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = snake_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123abc456def");
+
+            let result = snake_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc456def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = snake_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
+
+        #[test]
+        fn alphabets_and_numbers_in_separators_no_effect() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-b2",
+                keep: "",
+            };
+            let result = snake_case_with_options("abc123def", &opts);
+            assert_eq!(result, "abc123def");
+        }
     }
 
-    #[test]
-    fn it_should_convert_when_starting_with_digit() {
-        let result = snake_case_with_nums_as_word("123abc456def");
-        assert_eq!(result, "123_abc_456_def");
+    mod non_alphabets_as_head_of_a_word_with_kept_characters {
+        use super::*;
 
-        let result = snake_case_with_nums_as_word("123ABC456DEF");
-        assert_eq!(result, "123_abc_456_def");
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = snake_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = snake_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.keep = "_";
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc__def__ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.keep = "-";
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc_-def_-ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.keep = "-";
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc_-_def_-_ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.keep = "_";
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc__def__ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.keep = "-";
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc_-def_-ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc_123_456def_g_89hi_jkl_mn_12");
+
+            opts.keep = "-";
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc_123-456def_g_89hi_jkl_mn_12");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+            let result = snake_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123abc_456def");
+
+            let result = snake_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc_456def");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: ".~!#%?",
+            };
+            let result = snake_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".abc_~!_def_#_ghi_%_jk_lm_no_?");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = snake_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_treat_marks_as_separators() {
-        let result = snake_case_with_nums_as_word(":.abc~!@def#$ghi%&jk(lm)no/?");
-        assert_eq!(result, "abc_def_ghi_jk_lm_no");
+    mod non_alphabets_as_tail_of_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = snake_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = snake_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.keep = "_";
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc__def__ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.keep = "-";
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-_def-_ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.keep = "-";
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-_def-_ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.keep = "_";
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc__def__ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.keep = "-";
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-_def-_ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123_456_def_g89_hi_jkl_mn12");
+
+            opts.keep = "-";
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123-456_def_g89_hi_jkl_mn12");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+            let result = snake_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123_abc456_def");
+
+            opts.keep = "_";
+            let result = snake_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123_abc456_def");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: ".~!#%?",
+            };
+            let result = snake_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "._abc~!_def#_ghi%_jk_lm_no_?");
+        }
+
+        #[test]
+        fn convert_an_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = snake_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_empty() {
-        let result = snake_case_with_nums_as_word("");
-        assert_eq!(result, "");
-    }
-}
+    mod non_alphabets_as_a_word_with_kept_characters {
+        use super::*;
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = snake_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
 
-#[cfg(test)]
-mod tests_of_snake_case_with_sep {
-    use super::*;
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = snake_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
 
-    #[test]
-    fn it_should_convert_camel_case() {
-        let result = snake_case_with_sep("abcDefGHIjk", "-_");
-        assert_eq!(result, "abc_def_gh_ijk");
-    }
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
 
-    #[test]
-    fn it_should_convert_pascal_case() {
-        let result = snake_case_with_sep("AbcDefGHIjk", "-_");
-        assert_eq!(result, "abc_def_gh_ijk");
-    }
+            opts.keep = "_";
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc___def___ghi");
+        }
 
-    #[test]
-    fn it_should_convert_kebab_case() {
-        let result = snake_case_with_sep("abc-def-ghi", "-");
-        assert_eq!(result, "abc_def_ghi");
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
 
-        let result = snake_case_with_sep("abc-def-ghi", "_");
-        assert_eq!(result, "abc-_def-_ghi");
-    }
+            opts.keep = "-";
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc_-_def_-_ghi");
+        }
 
-    #[test]
-    fn it_should_convert_train_case() {
-        let result = snake_case_with_sep("Abc-Def-Ghi", "-");
-        assert_eq!(result, "abc_def_ghi");
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
 
-        let result = snake_case_with_sep("Abc-Def-Ghi", "_");
-        assert_eq!(result, "abc-_def-_ghi");
-    }
+            opts.keep = "-";
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc_-_def_-_ghi");
+        }
 
-    #[test]
-    fn it_should_convert_macro_case() {
-        let result = snake_case_with_sep("ABC_DEF_GHI", "_");
-        assert_eq!(result, "abc_def_ghi");
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
 
-        let result = snake_case_with_sep("ABC_DEF_GHI", "-");
-        assert_eq!(result, "abc__def__ghi");
-    }
+            opts.keep = "_";
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc___def___ghi");
+        }
 
-    #[test]
-    fn it_should_convert_cobol_case() {
-        let result = snake_case_with_sep("ABC-DEF-GHI", "-");
-        assert_eq!(result, "abc_def_ghi");
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
 
-        let result = snake_case_with_sep("ABC-DEF-GHI", "_");
-        assert_eq!(result, "abc-_def-_ghi");
-    }
+            opts.keep = "-";
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc_-_def_-_ghi");
+        }
 
-    #[test]
-    fn it_should_keep_digits() {
-        let result = snake_case_with_sep("abc123-456defG789HIJklMN12", "-");
-        assert_eq!(result, "abc123_456_def_g789_hi_jkl_mn12");
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc_123_456_def_g_89_hi_jkl_mn_12");
 
-        let result = snake_case_with_sep("abc123-456defG789HIJklMN12", "_");
-        assert_eq!(result, "abc123-456_def_g789_hi_jkl_mn12");
-    }
+            opts.keep = "-";
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc_123-456_def_g_89_hi_jkl_mn_12");
+        }
 
-    #[test]
-    fn it_should_convert_when_starting_with_digit() {
-        let result = snake_case_with_sep("123abc456def", "-");
-        assert_eq!(result, "123_abc456_def");
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+            let result = snake_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123_abc_456_def");
 
-        let result = snake_case_with_sep("123ABC456DEF", "_");
-        assert_eq!(result, "123_abc456_def");
-    }
+            let result = snake_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123_abc_456_def");
+        }
 
-    #[test]
-    fn it_should_treat_marks_as_separators() {
-        let result = snake_case_with_sep(":.abc~!@def#$ghi%&jk(lm)no/?", ":@$&()/");
-        assert_eq!(result, "._abc~!_def#_ghi%_jk_lm_no_?");
-    }
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: ".~!#%?",
+            };
+            let result = snake_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "._abc_~!_def_#_ghi_%_jk_lm_no_?");
+        }
 
-    #[test]
-    fn it_should_convert_empty() {
-        let result = snake_case_with_sep("", "_-");
-        assert_eq!(result, "");
-    }
-}
-
-#[cfg(test)]
-mod tests_of_snake_case_with_keep {
-    use super::*;
-
-    #[test]
-    fn it_should_convert_camel_case() {
-        let result = snake_case_with_keep("abcDefGHIjk", "-_");
-        assert_eq!(result, "abc_def_gh_ijk");
-    }
-
-    #[test]
-    fn it_should_convert_pascal_case() {
-        let result = snake_case_with_keep("AbcDefGHIjk", "-_");
-        assert_eq!(result, "abc_def_gh_ijk");
-    }
-
-    #[test]
-    fn it_should_convert_kebab_case() {
-        let result = snake_case_with_keep("abc-def-ghi", "_");
-        assert_eq!(result, "abc_def_ghi");
-
-        let result = snake_case_with_keep("abc-def-ghi", "-");
-        assert_eq!(result, "abc-_def-_ghi");
-    }
-
-    #[test]
-    fn it_should_convert_train_case() {
-        let result = snake_case_with_keep("Abc-Def-Ghi", "_");
-        assert_eq!(result, "abc_def_ghi");
-
-        let result = snake_case_with_keep("Abc-Def-Ghi", "-");
-        assert_eq!(result, "abc-_def-_ghi");
-    }
-
-    #[test]
-    fn it_should_convert_macro_case() {
-        let result = snake_case_with_keep("ABC_DEF_GHI", "-");
-        assert_eq!(result, "abc_def_ghi");
-
-        let result = snake_case_with_keep("ABC_DEF_GHI", "_");
-        assert_eq!(result, "abc__def__ghi");
-    }
-
-    #[test]
-    fn it_should_convert_cobol_case() {
-        let result = snake_case_with_keep("ABC-DEF-GHI", "_");
-        assert_eq!(result, "abc_def_ghi");
-
-        let result = snake_case_with_keep("ABC-DEF-GHI", "-");
-        assert_eq!(result, "abc-_def-_ghi");
-    }
-
-    #[test]
-    fn it_should_keep_digits() {
-        let result = snake_case_with_keep("abc123-456defG789HIJklMN12", "_");
-        assert_eq!(result, "abc123_456_def_g789_hi_jkl_mn12");
-
-        let result = snake_case_with_keep("abc123-456defG789HIJklMN12", "-");
-        assert_eq!(result, "abc123-456_def_g789_hi_jkl_mn12");
-    }
-
-    #[test]
-    fn it_should_convert_when_starting_with_digit() {
-        let result = snake_case_with_keep("123abc456def", "-");
-        assert_eq!(result, "123_abc456_def");
-
-        let result = snake_case_with_keep("123ABC456DEF", "_");
-        assert_eq!(result, "123_abc456_def");
-    }
-
-    #[test]
-    fn it_should_treat_marks_as_separators() {
-        let result = snake_case_with_keep(":.abc~!@def#$ghi%&jk(lm)no/?", ".~!#%?");
-        assert_eq!(result, "._abc~!_def#_ghi%_jk_lm_no_?");
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = snake_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 
-    #[test]
-    fn it_should_convert_empty() {
-        let result = snake_case_with_sep("", "_-");
-        assert_eq!(result, "");
+    mod non_alphabets_as_part_of_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = snake_case_with_options("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = snake_case_with_options("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc_def_gh_ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.keep = "_";
+            let result = snake_case_with_options("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.keep = "-";
+            let result = snake_case_with_options("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.keep = "-";
+            let result = snake_case_with_options("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-_def-_ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.keep = "_";
+            let result = snake_case_with_options("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+
+            opts.keep = "-";
+            let result = snake_case_with_options("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123_456def_g89hi_jkl_mn12");
+
+            opts.keep = "-";
+            let result = snake_case_with_options("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123-456def_g89hi_jkl_mn12");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+            let result = snake_case_with_options("123abc456def", &opts);
+            assert_eq!(result, "123abc456def");
+
+            let result = snake_case_with_options("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc456def");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: ".~!#%?",
+            };
+            let result = snake_case_with_options(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".abc~!_def#_ghi%_jk_lm_no_?");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = snake_case_with_options("", &opts);
+            assert_eq!(result, "");
+        }
     }
 }

--- a/tests/caser_test.rs
+++ b/tests/caser_test.rs
@@ -194,19 +194,37 @@ fn it_should_convert_to_snake_case_by_method_of_string() {
 
 #[test]
 fn it_should_convert_to_snake_case_with_nums_as_word_by_method_of_string() {
-    let converted = "foo_bar100BAZQux".to_snake_case_with_nums_as_word();
+    let opts = Options {
+        separate_before_non_alphabets: true,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "",
+    };
+    let converted = "foo_bar100BAZQux".to_snake_case_with_options(&opts);
     assert_eq!(converted, "foo_bar_100_baz_qux");
 }
 
 #[test]
 fn it_should_convert_to_snake_case_with_sep_by_method_of_string() {
-    let converted = "foo_bar100BAZQux".to_snake_case_with_sep("_");
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "_",
+        keep: "",
+    };
+    let converted = "foo_bar100BAZQux".to_snake_case_with_options(&opts);
     assert_eq!(converted, "foo_bar100_baz_qux");
 }
 
 #[test]
 fn it_should_convert_to_snake_case_with_keep_by_method_of_string() {
-    let converted = "foo_bar100BAZQux".to_snake_case_with_keep("#");
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "#",
+    };
+    let converted = "foo_bar100BAZQux".to_snake_case_with_options(&opts);
     assert_eq!(converted, "foo_bar100_baz_qux");
 }
 

--- a/tests/snake_case_test.rs
+++ b/tests/snake_case_test.rs
@@ -1,4 +1,4 @@
-use stringcase::{snake_case, snake_case_with_keep, snake_case_with_sep};
+use stringcase::{snake_case, snake_case_with_options, Options};
 
 #[test]
 fn it_should_convert_to_snake_case() {
@@ -8,20 +8,36 @@ fn it_should_convert_to_snake_case() {
 
 #[test]
 fn it_should_convert_to_snake_case_with_sep() {
-    let converted = snake_case_with_sep("foo_bar100%BAZQux", "_");
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "_",
+        keep: "",
+    };
+    let converted = snake_case_with_options("foo_bar100%BAZQux", &opts);
     assert_eq!(converted, "foo_bar100%_baz_qux");
 }
 
 #[test]
 fn it_should_convert_to_snake_case_with_keep() {
-    let converted = snake_case_with_keep("foo_bar100%BAZQux", "%");
+    let opts = Options {
+        separate_before_non_alphabets: false,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "%",
+    };
+    let converted = snake_case_with_options("foo_bar100%BAZQux", &opts);
     assert_eq!(converted, "foo_bar100%_baz_qux");
 }
 
 #[test]
 fn it_should_convert_to_snake_case_with_nums_as_word() {
-    use stringcase::snake_case_with_nums_as_word as snake_case;
-
-    let converted = snake_case("foo-bar100%-baz-qux");
+    let opts = Options {
+        separate_before_non_alphabets: true,
+        separate_after_non_alphabets: true,
+        separators: "",
+        keep: "",
+    };
+    let converted = snake_case_with_options("foo-bar100%-baz-qux", &opts);
     assert_eq!(converted, "foo_bar_100_baz_qux");
 }


### PR DESCRIPTION
(Related to #24)

This PR adds the new function `snake_case_with_options`, which supports handling non alphabetical characters, separators, and kept characters with `Options`.

`snake_case` is changed to use this function inside, and `snake_case_with_nums_as_word`,  `snake_case_with_sep` and `snake_case_with_keep` are deprecated.