### PR TITLE
cicd: updated github actions and target rust versions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,10 +11,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rustver: ['1.56.1', '1.60.0', '1.70.0', '1.80.0', stable]
+        rustver: ['1.56.1', '1.59.0', '1.69.0', '1.79.0', '1.80.0', stable]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rustver }}
@@ -29,7 +29,7 @@ jobs:
         rustver: [stable]
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rustver }}

--- a/benches/cobol_case_bench.rs
+++ b/benches/cobol_case_bench.rs
@@ -7,7 +7,7 @@ use test::Bencher;
 use stringcase::{cobol_case, cobol_case_with_options, Options};
 
 #[allow(deprecated)]
-use stringcase::{cobol_case_with_nums_as_word, cobol_case_with_sep, cobol_case_with_keep};
+use stringcase::{cobol_case_with_keep, cobol_case_with_nums_as_word, cobol_case_with_sep};
 
 #[bench]
 fn bench_cobol_case(b: &mut Bencher) {


### PR DESCRIPTION
This PR updates `actions/checkout` to v5 and updates the target Rust versions for CI.