### PR TITLE
feat: added upperize, lowerize, and capitalize functions

### DIFF
--- a/src/capitalize.rs
+++ b/src/capitalize.rs
@@ -29,9 +29,8 @@ use crate::options::Options;
 ///
 /// # Returns
 ///
-/// - **Normal Return**: Returns a [`String`] with all words capitalized and joined by
-///   `CONCATENATOR`. Returns an empty [`String`] if `input` is empty.
-/// - **Error Return**: This function is infallible and does not return a [`Result`] or panic.
+/// - Returns a [`String`] with all words capitalized and joined by `CONCATENATOR`.
+///   Returns an empty [`String`] if `input` is empty.
 ///
 /// # Examples
 ///

--- a/src/capitalize.rs
+++ b/src/capitalize.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2026 Takayuki Sato. All Rights Reserved.
+// Copyright (C) 2026 Takayuki Sato. All Rights Reserved.
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
@@ -17,6 +17,8 @@ use crate::options::Options;
 /// symbols) according to options such as `opts.separators`, `opts.keep`,
 /// `opts.separate_before_non_alphabets`, and `opts.separate_after_non_alphabets` to determine
 /// word boundaries, capitalize initial letters, and insert the `CONCATENATOR` character.
+/// If a character is specified in both `opts.separators` and `opts.keep`, the character in
+/// `opts.separators` takes precedence and the character in `opts.keep` is ignored.
 ///
 /// # Parameters
 ///
@@ -27,8 +29,9 @@ use crate::options::Options;
 ///
 /// # Returns
 ///
-/// - Returns a [`String`] with all words capitalized and joined by `CONCATENATOR`.
-///   Returns an empty [`String`] if `input` is empty.
+/// - **Normal Return**: Returns a [`String`] with all words capitalized and joined by
+///   `CONCATENATOR`. Returns an empty [`String`] if `input` is empty.
+/// - **Error Return**: This function is infallible and does not return a [`Result`] or panic.
 ///
 /// # Examples
 ///

--- a/src/capitalize.rs
+++ b/src/capitalize.rs
@@ -1,0 +1,2083 @@
+// Copyright (C) 2024-2026 Takayuki Sato. All Rights Reserved.
+// This program is free software under MIT License.
+// See the file LICENSE in this distribution for more details.
+
+use crate::options::Options;
+
+/// A generic function that converts string cases into a capitalized format joined by a specified
+/// concatenator character.
+///
+/// It processes the input string `input`, identifies word boundaries based on character casing and
+/// non-alphabetic character rules defined in `opts`, capitalizes the head character of each word,
+/// lowercases subsequent letters, and joins the words using the const generic character
+/// `CONCATENATOR`.
+///
+/// It operates by iterating character by character through `input` using an internal state
+/// machine. It handles ASCII uppercase, ASCII lowercase, and non-alphabetic characters (digits and
+/// symbols) according to options such as `opts.separators`, `opts.keep`,
+/// `opts.separate_before_non_alphabets`, and `opts.separate_after_non_alphabets` to determine
+/// word boundaries, capitalize initial letters, and insert the `CONCATENATOR` character.
+///
+/// # Parameters
+///
+/// - `CONCATENATOR`: A const generic `char` used as the delimiter between capitalized words.
+/// - `input`: The target string slice (`&str`) to be capitalized.
+/// - `opts`: A reference to [`Options`] defining separator rules, retained characters, and boundary
+///   behaviors.
+///
+/// # Returns
+///
+/// - Returns a [`String`] with all words capitalized and joined by `CONCATENATOR`.
+///   Returns an empty [`String`] if `input` is empty.
+///
+/// # Examples
+///
+/// ```rust
+/// use stringcase::{capitalize, Options};
+///
+/// let opts = Options {
+///     separate_before_non_alphabets: true,
+///     separate_after_non_alphabets: true,
+///     separators: "",
+///     keep: "",
+/// };
+/// let result = capitalize::<'.'>("foo_bar_100_baz", &opts);
+/// assert_eq!(result, "Foo.Bar.100.Baz");
+/// ```
+pub fn capitalize<const CONCATENATOR: char>(input: &str, opts: &Options) -> String {
+    let mut result = String::with_capacity(input.len() + input.len() / 2);
+    // .len returns byte count but ok in this case!
+
+    #[derive(PartialEq)]
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfSepMark,
+        NextOfKeptMark,
+        Other,
+    }
+
+    let mut flag = ChIs::FirstOfStr;
+
+    for ch in input.chars() {
+        if ch.is_ascii_uppercase() {
+            if flag == ChIs::FirstOfStr {
+                result.push(ch);
+                flag = ChIs::NextOfUpper;
+            } else if flag == ChIs::NextOfUpper
+                || flag == ChIs::NextOfContdUpper
+                || (!opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
+            {
+                result.push(ch.to_ascii_lowercase());
+                flag = ChIs::NextOfContdUpper;
+            } else {
+                result.push(CONCATENATOR);
+                result.push(ch);
+                flag = ChIs::NextOfUpper;
+            }
+        } else if ch.is_ascii_lowercase() {
+            if flag == ChIs::FirstOfStr {
+                result.push(ch.to_ascii_uppercase());
+            } else if flag == ChIs::NextOfContdUpper {
+                if let Some(prev) = result.pop() {
+                    result.push(CONCATENATOR);
+                    result.push(prev.to_ascii_uppercase());
+                    result.push(ch);
+                }
+            } else if flag == ChIs::NextOfSepMark
+                || (opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
+            {
+                result.push(CONCATENATOR);
+                result.push(ch.to_ascii_uppercase());
+            } else {
+                result.push(ch);
+            }
+            flag = ChIs::Other;
+        } else {
+            let mut is_kept_char = false;
+            if ch.is_ascii_digit() {
+                is_kept_char = true;
+            } else if !opts.separators.is_empty() {
+                if !opts.separators.contains(ch) {
+                    is_kept_char = true;
+                }
+            } else if !opts.keep.is_empty() {
+                #[allow(clippy::collapsible_if)]
+                if opts.keep.contains(ch) {
+                    is_kept_char = true;
+                }
+            }
+
+            if is_kept_char {
+                if opts.separate_before_non_alphabets {
+                    if flag == ChIs::FirstOfStr || flag == ChIs::NextOfKeptMark {
+                        result.push(ch);
+                    } else {
+                        result.push(CONCATENATOR);
+                        result.push(ch);
+                    }
+                } else {
+                    if flag != ChIs::NextOfSepMark {
+                        result.push(ch);
+                    } else {
+                        result.push(CONCATENATOR);
+                        result.push(ch);
+                    }
+                }
+                flag = ChIs::NextOfKeptMark;
+            } else {
+                if flag != ChIs::FirstOfStr {
+                    flag = ChIs::NextOfSepMark;
+                }
+            }
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests_of_capitalize {
+    use super::*;
+
+    mod non_alphabets_as_head_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_snake_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_capitalize() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_macro_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc.123.456def.G.89hi.Jkl.Mn.12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "Abc.Def.Ghi.Jk.Lm.No");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123abc.456def");
+
+            let result = capitalize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc.456def");
+
+            let result = capitalize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.Abc.456.Def");
+        }
+
+        #[test]
+        fn convert_empty_string_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_tail_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_snake_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_capitalize() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_macro_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc123.456.Def.G89.Hi.Jkl.Mn12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "Abc.Def.Ghi.Jk.Lm.No");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123.Abc456.Def");
+
+            let result = capitalize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123.Abc456.Def");
+
+            let result = capitalize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.Abc456.Def");
+        }
+
+        #[test]
+        fn convert_empty_string_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_snake_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_capitalize() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_macro_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc.123.456.Def.G.89.Hi.Jkl.Mn.12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "Abc.Def.Ghi.Jk.Lm.No");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123.Abc.456.Def");
+
+            let result = capitalize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123.Abc.456.Def");
+
+            let result = capitalize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.Abc.456.Def");
+        }
+
+        #[test]
+        fn convert_empty_string_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_part_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_snake_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_capitalize() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_macro_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc123.456def.G89hi.Jkl.Mn12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "Abc.Def.Ghi.Jk.Lm.No");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123abc456def");
+
+            let result = capitalize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc456def");
+
+            let result = capitalize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.Abc456.Def");
+        }
+
+        #[test]
+        fn convert_empty_string_with_options() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_head_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.separators = "-";
+            let result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc._def._ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.separators = "_";
+            let result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc.-def.-ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.separators = "_";
+            let result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc.-.Def.-.Ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.separators = "-";
+            let result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc._def._ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.separators = "_";
+            let result = capitalize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "Abc.-def.-ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc.123.456def.G.89hi.Jkl.Mn.12");
+
+            opts.separators = "_";
+            let result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc.123-456def.G.89hi.Jkl.Mn.12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = capitalize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".abc.~!.Def.#.Ghi.%.Jk.Lm.No.?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123abc.456def");
+
+            let result = capitalize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc.456def");
+
+            let result = capitalize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.Abc.456.Def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+
+        #[test]
+        fn alphabets_and_numbers_in_separators_have_no_effect() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-b2",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc123def", &opts);
+            assert_eq!(result, "Abc.123def");
+        }
+    }
+
+    mod non_alphabets_as_tail_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.separators = "-";
+            let result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc_.Def_.Ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.separators = "_";
+            let result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc-.Def-.Ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.separators = "_";
+            let result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc-.Def-.Ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.separators = "-";
+            let result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc_.Def_.Ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.separators = "_";
+            let result = capitalize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "Abc-.Def-.Ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc123.456.Def.G89.Hi.Jkl.Mn12");
+
+            opts.separators = "_";
+            let result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc123-456.Def.G89.Hi.Jkl.Mn12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = capitalize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "..Abc~!.Def#.Ghi%.Jk.Lm.No.?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123.Abc456.Def");
+
+            let result = capitalize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123.Abc456.Def");
+
+            let result = capitalize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.Abc456.Def");
+        }
+
+        #[test]
+        fn convert_an_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+
+        #[test]
+        fn alphabets_and_numbers_in_separators_are_no_effect() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-b2",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc123def", &opts);
+            assert_eq!(result, "Abc123.Def");
+        }
+    }
+
+    mod non_alphabets_as_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.separators = "-";
+            let result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc._.Def._.Ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.separators = "_";
+            let result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc.-.Def.-.Ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.separators = "_";
+            let result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc.-.Def.-.Ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.separators = "-";
+            let result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc._.Def._.Ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.separators = "_";
+            let result = capitalize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "Abc.-.Def.-.Ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc.123.456.Def.G.89.Hi.Jkl.Mn.12");
+
+            opts.separators = "_";
+            let result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc.123-456.Def.G.89.Hi.Jkl.Mn.12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = capitalize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "..Abc.~!.Def.#.Ghi.%.Jk.Lm.No.?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123.Abc.456.Def");
+
+            let result = capitalize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123.Abc.456.Def");
+
+            let result = capitalize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.Abc.456.Def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+
+        #[test]
+        fn alphabets_and_numbers_in_separators_no_effect() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-b2",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc123def", &opts);
+            assert_eq!(result, "Abc.123.Def");
+        }
+    }
+
+    mod non_alphabets_as_part_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.separators = "-";
+            let result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.separators = "_";
+            let result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.separators = "_";
+            let result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc-.Def-.Ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.separators = "-";
+            let result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc123.456def.G89hi.Jkl.Mn12");
+
+            opts.separators = "_";
+            let result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc123-456def.G89hi.Jkl.Mn12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = capitalize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".abc~!.Def#.Ghi%.Jk.Lm.No.?");
+        }
+
+        #[test]
+        fn convert_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123abc456def");
+
+            let result = capitalize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc456def");
+
+            let result = capitalize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.Abc456.Def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+
+        #[test]
+        fn alphabets_and_numbers_in_separators_have_no_effect() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-b2",
+                keep: "",
+            };
+            let result = capitalize::<'.'>("abc123def", &opts);
+            assert_eq!(result, "Abc123def");
+        }
+    }
+
+    mod non_alphabets_as_head_of_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = capitalize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = capitalize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+            let mut result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "_";
+            result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc._def._ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let mut result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "-";
+            result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc.-def.-ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let mut result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "-";
+            result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc.-.Def.-.Ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+            let mut result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "_";
+            result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc._def._ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let mut result = capitalize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "-";
+            result = capitalize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "Abc.-def.-ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let mut result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc.123.456def.G.89hi.Jkl.Mn.12");
+
+            opts.keep = "-";
+            result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc.123-456def.G.89hi.Jkl.Mn.12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: ".~!#%?",
+            };
+            let result = capitalize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".abc.~!.Def.#.Ghi.%.Jk.Lm.No.?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+            let mut result = capitalize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123abc.456def");
+
+            result = capitalize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc.456def");
+
+            result = capitalize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.Abc.456.Def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = capitalize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+
+        #[test]
+        fn alphabets_and_numbers_in_separators_have_no_effect() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-b2",
+            };
+            let result = capitalize::<'.'>("abc123def", &opts);
+            assert_eq!(result, "Abc.123def");
+        }
+    }
+
+    mod non_alphabets_as_tail_of_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = capitalize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = capitalize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+            let result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "_";
+            let result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc_.Def_.Ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "-";
+            let result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc-.Def-.Ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "-";
+            let result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc-.Def-.Ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+            let result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "_";
+            let result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc_.Def_.Ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = capitalize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "-";
+            let result = capitalize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "Abc-.Def-.Ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc123.456.Def.G89.Hi.Jkl.Mn12");
+
+            opts.keep = "-";
+            let result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc123-456.Def.G89.Hi.Jkl.Mn12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: ".~!#%?",
+            };
+            let result = capitalize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "..Abc~!.Def#.Ghi%.Jk.Lm.No.?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+            let result = capitalize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123.Abc456.Def");
+
+            let result = capitalize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123.Abc456.Def");
+
+            let result = capitalize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.Abc456.Def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = capitalize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = capitalize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = capitalize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+            let result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "_";
+            let result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc._.Def._.Ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "-";
+            let result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc.-.Def.-.Ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "-";
+            let result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc.-.Def.-.Ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+            let result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "_";
+            let result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc._.Def._.Ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = capitalize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "-";
+            let result = capitalize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "Abc.-.Def.-.Ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc.123.456.Def.G.89.Hi.Jkl.Mn.12");
+
+            opts.keep = "-";
+            let result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc.123-456.Def.G.89.Hi.Jkl.Mn.12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: ".~!#%?",
+            };
+            let result = capitalize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "..Abc.~!.Def.#.Ghi.%.Jk.Lm.No.?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = capitalize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123.Abc.456.Def");
+
+            let result = capitalize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123.Abc.456.Def");
+
+            let result = capitalize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.Abc.456.Def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = capitalize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_part_of_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = capitalize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = capitalize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "Abc.Def.Gh.Ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+            let result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "_";
+            let result = capitalize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "Abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "-";
+            let result = capitalize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "Abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "-";
+            let result = capitalize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "Abc-.Def-.Ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+            let result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "_";
+            let result = capitalize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "Abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = capitalize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "Abc.Def.Ghi");
+
+            opts.keep = "-";
+            let result = capitalize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "Abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_with_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc123.456def.G89hi.Jkl.Mn12");
+
+            opts.keep = "-";
+            let result = capitalize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "Abc123-456def.G89hi.Jkl.Mn12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: ".~!#%?",
+            };
+            let result = capitalize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".abc~!.Def#.Ghi%.Jk.Lm.No.?");
+        }
+
+        #[test]
+        fn convert_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = capitalize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123abc456def");
+
+            let result = capitalize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc456def");
+
+            let result = capitalize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.Abc456.Def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = capitalize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Takayuki Sato. All Rights Reserved.
+// Copyright (C) 2024-2026 Takayuki Sato. All Rights Reserved.
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 
 //! This library provides some functions that convert string cases between camelCase, COBOL-CASE,
 //! kebab-case, MACRO_CASE, PascalCase, snake_case and Train-Case.
+//! In addition, generic functions `capitalize`, `lowerize`, and `upperize` are provided to convert
+//! string cases with a custom concatenator character.
 //! And this library also provides a trait `Caser` which enables strings to convert themselves
 //! to their cases by their own methods.
 //!
@@ -63,6 +65,26 @@
 //! }
 //! ```
 //!
+//! You can also use the generic functions `capitalize`, `lowerize`, and `upperize` to convert
+//! strings into capitalized, lowercased, or uppercased words joined by a custom concatenator
+//! character:
+//!
+//! ```rust
+//! use stringcase::{capitalize, lowerize, upperize, Options};
+//!
+//! fn main() {
+//!     let opts = Options {
+//!         separate_before_non_alphabets: true,
+//!         separate_after_non_alphabets: true,
+//!         ..Default::default()
+//!     };
+//!     let input = "fooBar123Baz";
+//!     assert_eq!(capitalize::<'.'>(input, &opts), "Foo.Bar.123.Baz");
+//!     assert_eq!(lowerize::<'.'>(input, &opts), "foo.bar.123.baz");
+//!     assert_eq!(upperize::<'.'>(input, &opts), "FOO.BAR.123.BAZ");
+//! }
+//! ```
+//!
 //! And by bringing `Caser` with `use` declaration, it will be able to execute
 //! methods of strings, `String` or `&str`, to convert to their cases.
 //!
@@ -80,22 +102,35 @@
 //! }
 //! ```
 
-mod camel_case;
-mod caser;
-mod cobol_case;
-mod kebab_case;
-mod macro_case;
 mod options;
-mod pascal_case;
-mod snake_case;
-mod train_case;
-
-pub use camel_case::*;
-pub use caser::*;
-pub use cobol_case::*;
-pub use kebab_case::*;
-pub use macro_case::*;
 pub use options::Options;
-pub use pascal_case::*;
+
+mod upperize;
+pub use upperize::upperize;
+
+mod cobol_case;
+mod macro_case;
+pub use cobol_case::*;
+pub use macro_case::*;
+
+mod lowerize;
+pub use lowerize::lowerize;
+
+mod kebab_case;
+mod snake_case;
+pub use kebab_case::*;
 pub use snake_case::*;
+
+mod capitalize;
+pub use capitalize::capitalize;
+
+mod pascal_case;
+mod train_case;
+pub use pascal_case::*;
 pub use train_case::*;
+
+mod camel_case;
+pub use camel_case::*;
+
+mod caser;
+pub use caser::*;

--- a/src/lowerize.rs
+++ b/src/lowerize.rs
@@ -1,0 +1,2197 @@
+// Copyright (C) 2026 Takayuki Sato. All Rights Reserved.
+// This program is free software under MIT License.
+// See the file LICENSE in this distribution for more details.
+
+use crate::options::Options;
+
+/// A generic function that converts string cases into a lowercased format joined by a specified
+/// concatenator character.
+///
+/// It processes the input string `input`, identifies word boundaries based on character casing and
+/// non-alphabetic character rules defined in `opts`, converts alphabetic characters to lowercase,
+/// and joins the words using the const generic character `CONCATENATOR`.
+///
+/// It operates by iterating character by character through `input` using an internal state
+/// machine. It handles ASCII uppercase, ASCII lowercase, and non-alphabetic characters (digits and
+/// symbols) according to options such as `opts.separators`, `opts.keep`,
+/// `opts.separate_before_non_alphabets`, and `opts.separate_after_non_alphabets` to determine
+/// word boundaries, lowerizing characters, and insert the `CONCATENATOR` character.
+///
+/// # Parameters
+///
+/// - `CONCATENATOR`: A const generic `char` used as the delimiter between lowercased words.
+/// - `input`: The target string slice (`&str`) to be lowercased.
+/// - `opts`: A reference to [`Options`] defining separator rules, retained characters, and boundary
+///   behaviors.
+///
+/// # Returns
+///
+/// - Returns a [`String`] with all words lowercased and joined by `CONCATENATOR`.
+///   Returns an empty [`String`] if `input` is empty.
+///
+/// # Examples
+///
+/// ```rust
+/// use stringcase::{lowerize, Options};
+///
+/// let opts = Options {
+///     separate_before_non_alphabets: true,
+///     separate_after_non_alphabets: true,
+///     separators: "",
+///     keep: "",
+/// };
+/// let result = lowerize::<'.' >("foo_bar_100_baz", &opts);
+/// assert_eq!(result, "foo.bar.100.baz");
+/// ```
+pub fn lowerize<const CONCATENATOR: char>(input: &str, opts: &Options) -> String {
+    let mut result = String::with_capacity(input.len() + input.len() / 2);
+    // .len returns byte count but ok in this case!
+
+    #[derive(PartialEq)]
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfSepMark,
+        NextOfKeptMark,
+        Other,
+    }
+
+    let mut flag = ChIs::FirstOfStr;
+
+    for ch in input.chars() {
+        if ch.is_ascii_uppercase() {
+            if flag == ChIs::FirstOfStr {
+                result.push(ch.to_ascii_lowercase());
+                flag = ChIs::NextOfUpper;
+            } else if flag == ChIs::NextOfUpper
+                || flag == ChIs::NextOfContdUpper
+                || (!opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
+            {
+                result.push(ch.to_ascii_lowercase());
+                flag = ChIs::NextOfContdUpper;
+            } else {
+                result.push(CONCATENATOR);
+                result.push(ch.to_ascii_lowercase());
+                flag = ChIs::NextOfUpper;
+            }
+        } else if ch.is_ascii_lowercase() {
+            if flag == ChIs::NextOfContdUpper {
+                if let Some(prev) = result.pop() {
+                    result.push(CONCATENATOR);
+                    result.push(prev);
+                    result.push(ch);
+                }
+            } else if flag == ChIs::NextOfSepMark
+                || (opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
+            {
+                result.push(CONCATENATOR);
+                result.push(ch);
+            } else {
+                result.push(ch);
+            }
+            flag = ChIs::Other;
+        } else {
+            let mut is_kept_char = false;
+            if ch.is_ascii_digit() {
+                is_kept_char = true;
+            } else if !opts.separators.is_empty() {
+                if !opts.separators.contains(ch) {
+                    is_kept_char = true;
+                }
+            } else if !opts.keep.is_empty() {
+                #[allow(clippy::collapsible_if)]
+                if opts.keep.contains(ch) {
+                    is_kept_char = true;
+                }
+            }
+
+            if is_kept_char {
+                if opts.separate_before_non_alphabets {
+                    if flag == ChIs::FirstOfStr || flag == ChIs::NextOfKeptMark {
+                        result.push(ch);
+                    } else {
+                        result.push(CONCATENATOR);
+                        result.push(ch);
+                    }
+                } else {
+                    if flag != ChIs::NextOfSepMark {
+                        result.push(ch);
+                    } else {
+                        result.push(CONCATENATOR);
+                        result.push(ch);
+                    }
+                }
+                flag = ChIs::NextOfKeptMark;
+            } else {
+                if flag != ChIs::FirstOfStr {
+                    flag = ChIs::NextOfSepMark;
+                }
+            }
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests_of_lowerize {
+    use super::*;
+
+    mod non_alphabets_as_head_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc.123.456def.g.89hi.jkl.mn.12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "abc.def.ghi.jk.lm.no");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123abc.456def");
+
+            let result = lowerize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc.456def");
+
+            let result = lowerize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.abc.456.def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_tail_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123.456.def.g89.hi.jkl.mn12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "abc.def.ghi.jk.lm.no");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123.abc456.def");
+
+            let result = lowerize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123.abc456.def");
+
+            let result = lowerize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.abc456.def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc.123.456.def.g.89.hi.jkl.mn.12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "abc.def.ghi.jk.lm.no");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123.abc.456.def");
+
+            let result = lowerize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123.abc.456.def");
+
+            let result = lowerize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.abc.456.def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_part_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123.456def.g89hi.jkl.mn12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "abc.def.ghi.jk.lm.no");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123abc456def");
+
+            let result = lowerize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc456def");
+
+            let result = lowerize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.abc456.def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_head_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "-";
+            result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc._def._ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "_";
+            result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc.-def.-ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "_";
+            result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc.-.def.-.ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "-";
+            result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc._def._ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "_";
+            result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc.-def.-ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc.123.456def.g.89hi.jkl.mn.12");
+
+            opts.separators = "_";
+            result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc.123-456def.g.89hi.jkl.mn.12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: ":@$&()/",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".abc.~!.def.#.ghi.%.jk.lm.no.?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123abc.456def");
+
+            let result = lowerize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc.456def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+
+        #[test]
+        fn alphabets_and_numbers_in_separators_are_no_effect() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-b2",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abc123def", &opts);
+            assert_eq!(result, "abc.123def");
+        }
+    }
+
+    mod non_alphabets_as_tail_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "-";
+            result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_.def_.ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "_";
+            result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-.def-.ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "_";
+            result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-.def-.ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "-";
+            result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_.def_.ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "_";
+            result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-.def-.ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123.456.def.g89.hi.jkl.mn12");
+
+            opts.separators = "_";
+            result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123-456.def.g89.hi.jkl.mn12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: ":@$&()/",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "..abc~!.def#.ghi%.jk.lm.no.?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123.abc456.def");
+
+            let result = lowerize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123.abc456.def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+
+        #[test]
+        fn alphabets_and_numbers_in_separators_are_no_effect() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-b2",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abc123def", &opts);
+            assert_eq!(result, "abc123.def");
+        }
+    }
+
+    mod non_alphabets_as_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "-";
+            result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc._.def._.ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "_";
+            result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc.-.def.-.ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "_";
+            result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc.-.def.-.ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "-";
+            result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc._.def._.ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "_";
+            result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc.-.def.-.ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc.123.456.def.g.89.hi.jkl.mn.12");
+
+            opts.separators = "_";
+            result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc.123-456.def.g.89.hi.jkl.mn.12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: ":@$&()/",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "..abc.~!.def.#.ghi.%.jk.lm.no.?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123.abc.456.def");
+
+            let result = lowerize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123.abc.456.def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+
+        #[test]
+        fn alphabets_and_numbers_in_separators_are_no_effect() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-b2",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abc123def", &opts);
+            assert_eq!(result, "abc.123.def");
+        }
+    }
+
+    mod non_alphabets_as_part_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "-";
+            result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "_";
+            result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "_";
+            result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-.def-.ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "-";
+            result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.separators = "_";
+            result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let mut result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123.456def.g89hi.jkl.mn12");
+
+            opts.separators = "_";
+            result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123-456def.g89hi.jkl.mn12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: ":@$&()/",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".abc~!.def#.ghi%.jk.lm.no.?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123abc456def");
+
+            let result = lowerize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc456def");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+
+        #[test]
+        fn alphabets_and_numbers_in_separators_are_no_effect() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-b2",
+                keep: "",
+            };
+
+            let result = lowerize::<'.'>("abc123def", &opts);
+            assert_eq!(result, "abc123def");
+        }
+    }
+
+    mod non_alphabets_as_head_of_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = lowerize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = lowerize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+
+            let mut result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "_";
+            result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc._def._ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "-";
+            result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc.-def.-ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "-";
+            result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc.-.def.-.ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+
+            let mut result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "_";
+            result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc._def._ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "-";
+            result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc.-def.-ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc.123.456def.g.89hi.jkl.mn.12");
+
+            opts.keep = "-";
+            result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc.123-456def.g.89hi.jkl.mn.12");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+
+            let result = lowerize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123abc.456def");
+
+            let result = lowerize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc.456def");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: ".~!#%?",
+            };
+
+            let result = lowerize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".abc.~!.def.#.ghi.%.jk.lm.no.?");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = lowerize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_tail_of_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = lowerize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = lowerize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+
+            let mut result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "_";
+            result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_.def_.ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "-";
+            result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-.def-.ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "-";
+            result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-.def-.ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+
+            let mut result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "_";
+            result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_.def_.ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "-";
+            result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-.def-.ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123.456.def.g89.hi.jkl.mn12");
+
+            opts.keep = "-";
+            result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123-456.def.g89.hi.jkl.mn12");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+
+            let result = lowerize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123.abc456.def");
+
+            opts.keep = "_";
+            let result = lowerize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123.abc456.def");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: ".~!#%?",
+            };
+
+            let result = lowerize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "..abc~!.def#.ghi%.jk.lm.no.?");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = lowerize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = lowerize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = lowerize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+
+            let mut result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "_";
+            result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc._.def._.ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "-";
+            result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc.-.def.-.ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "-";
+            result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc.-.def.-.ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+
+            let mut result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "_";
+            result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc._.def._.ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "-";
+            result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc.-.def.-.ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc.123.456.def.g.89.hi.jkl.mn.12");
+
+            opts.keep = "-";
+            result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc.123-456.def.g.89.hi.jkl.mn.12");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+
+            let result = lowerize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123.abc.456.def");
+
+            let result = lowerize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123.abc.456.def");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: ".~!#%?",
+            };
+
+            let result = lowerize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "..abc.~!.def.#.ghi.%.jk.lm.no.?");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = lowerize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_part_of_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = lowerize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = lowerize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "abc.def.gh.ijk");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+
+            let mut result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "_";
+            result = lowerize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "-";
+            result = lowerize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "-";
+            result = lowerize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "abc-.def-.ghi");
+        }
+
+        #[test]
+        fn convert_macro_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+
+            let mut result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "_";
+            result = lowerize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "abc_def_ghi");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc.def.ghi");
+
+            opts.keep = "-";
+            result = lowerize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "abc-def-ghi");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+
+            let mut result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123.456def.g89hi.jkl.mn12");
+
+            opts.keep = "-";
+            result = lowerize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "abc123-456def.g89hi.jkl.mn12");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+
+            let result = lowerize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123abc456def");
+
+            let result = lowerize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123abc456def");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: ".~!#%?",
+            };
+
+            let result = lowerize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".abc~!.def#.ghi%.jk.lm.no.?");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+
+            let result = lowerize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+}

--- a/src/lowerize.rs
+++ b/src/lowerize.rs
@@ -28,9 +28,8 @@ use crate::options::Options;
 ///
 /// # Returns
 ///
-/// - **Normal Return**: Returns a [`String`] with all words lowercased and joined by
-///   `CONCATENATOR`. Returns an empty [`String`] if `input` is empty.
-/// - **Error Return**: This function is infallible and does not return a [`Result`] or panic.
+/// - Returns a [`String`] with all words lowercased and joined by `CONCATENATOR`.
+///   Returns an empty [`String`] if `input` is empty.
 ///
 /// # Examples
 ///

--- a/src/lowerize.rs
+++ b/src/lowerize.rs
@@ -16,6 +16,8 @@ use crate::options::Options;
 /// symbols) according to options such as `opts.separators`, `opts.keep`,
 /// `opts.separate_before_non_alphabets`, and `opts.separate_after_non_alphabets` to determine
 /// word boundaries, lowerizing characters, and insert the `CONCATENATOR` character.
+/// If a character is specified in both `opts.separators` and `opts.keep`, the character in
+/// `opts.separators` takes precedence and the character in `opts.keep` is ignored.
 ///
 /// # Parameters
 ///
@@ -26,8 +28,9 @@ use crate::options::Options;
 ///
 /// # Returns
 ///
-/// - Returns a [`String`] with all words lowercased and joined by `CONCATENATOR`.
-///   Returns an empty [`String`] if `input` is empty.
+/// - **Normal Return**: Returns a [`String`] with all words lowercased and joined by
+///   `CONCATENATOR`. Returns an empty [`String`] if `input` is empty.
+/// - **Error Return**: This function is infallible and does not return a [`Result`] or panic.
 ///
 /// # Examples
 ///

--- a/src/upperize.rs
+++ b/src/upperize.rs
@@ -1,0 +1,2036 @@
+// Copyright (C) 2026 Takayuki Sato. All Rights Reserved.
+// This program is free software under MIT License.
+// See the file LICENSE in this distribution for more details.
+
+use crate::options::Options;
+
+/// A generic function that converts string cases into an uppercased format joined by a specified
+/// concatenator character.
+///
+/// It processes the input string `input`, identifies word boundaries based on character casing and
+/// non-alphabetic character rules defined in `opts`, converts alphabetic characters to uppercase,
+/// and joins the words using the const generic character `CONCATENATOR`.
+///
+/// It operates by iterating character by character through `input` using an internal state
+/// machine. It handles ASCII uppercase, ASCII lowercase, and non-alphabetic characters (digits and
+/// symbols) according to options such as `opts.separators`, `opts.keep`,
+/// `opts.separate_before_non_alphabets`, and `opts.separate_after_non_alphabets` to determine
+/// word boundaries, upperizing characters, and insert the `CONCATENATOR` character.
+///
+/// # Parameters
+///
+/// - `CONCATENATOR`: A const generic `char` used as the delimiter between uppercased words.
+/// - `input`: The target string slice (`&str`) to be uppercased.
+/// - `opts`: A reference to [`Options`] defining separator rules, retained characters, and boundary
+///   behaviors.
+///
+/// # Returns
+///
+/// - Returns a [`String`] with all words uppercased and joined by `CONCATENATOR`.
+///   Returns an empty [`String`] if `input` is empty.
+///
+/// # Examples
+///
+/// ```rust
+/// use stringcase::{upperize, Options};
+///
+/// let opts = Options {
+///     separate_before_non_alphabets: true,
+///     separate_after_non_alphabets: true,
+///     separators: "",
+///     keep: "",
+/// };
+/// let result = upperize::<'.' >("foo_bar_100_baz", &opts);
+/// assert_eq!(result, "FOO.BAR.100.BAZ");
+/// ```
+pub fn upperize<const CONCATENATOR: char>(input: &str, opts: &Options) -> String {
+    let mut result = String::with_capacity(input.len() + input.len() / 2);
+    // .len returns byte count but ok in this case!
+
+    #[derive(PartialEq)]
+    enum ChIs {
+        FirstOfStr,
+        NextOfUpper,
+        NextOfContdUpper,
+        NextOfSepMark,
+        NextOfKeptMark,
+        Other,
+    }
+
+    let mut flag = ChIs::FirstOfStr;
+
+    for ch in input.chars() {
+        if ch.is_ascii_uppercase() {
+            if flag == ChIs::FirstOfStr {
+                result.push(ch);
+                flag = ChIs::NextOfUpper;
+            } else if flag == ChIs::NextOfUpper
+                || flag == ChIs::NextOfContdUpper
+                || (!opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
+            {
+                result.push(ch);
+                flag = ChIs::NextOfContdUpper;
+            } else {
+                result.push(CONCATENATOR);
+                result.push(ch);
+                flag = ChIs::NextOfUpper;
+            }
+        } else if ch.is_ascii_lowercase() {
+            if flag == ChIs::NextOfContdUpper {
+                if let Some(prev) = result.pop() {
+                    result.push(CONCATENATOR);
+                    result.push(prev);
+                    result.push(ch.to_ascii_uppercase());
+                }
+            } else if flag == ChIs::NextOfSepMark
+                || (opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
+            {
+                result.push(CONCATENATOR);
+                result.push(ch.to_ascii_uppercase());
+            } else {
+                result.push(ch.to_ascii_uppercase());
+            }
+            flag = ChIs::Other;
+        } else {
+            let mut is_kept_char = false;
+            if ch.is_ascii_digit() {
+                is_kept_char = true;
+            } else if !opts.separators.is_empty() {
+                if !opts.separators.contains(ch) {
+                    is_kept_char = true;
+                }
+            } else if !opts.keep.is_empty() {
+                #[allow(clippy::collapsible_if)]
+                if opts.keep.contains(ch) {
+                    is_kept_char = true;
+                }
+            }
+
+            if is_kept_char {
+                if opts.separate_before_non_alphabets {
+                    if flag == ChIs::FirstOfStr || flag == ChIs::NextOfKeptMark {
+                        result.push(ch);
+                    } else {
+                        result.push(CONCATENATOR);
+                        result.push(ch);
+                    }
+                } else {
+                    if flag != ChIs::NextOfSepMark {
+                        result.push(ch);
+                    } else {
+                        result.push(CONCATENATOR);
+                        result.push(ch);
+                    }
+                }
+                flag = ChIs::NextOfKeptMark;
+            } else {
+                if flag != ChIs::FirstOfStr {
+                    flag = ChIs::NextOfSepMark;
+                }
+            }
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests_of_upperize {
+    use super::*;
+
+    mod non_alphabets_as_head_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_upperize() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_with_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC.123.456DEF.G.89HI.JKL.MN.12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "ABC.DEF.GHI.JK.LM.NO");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123ABC.456DEF");
+
+            let result = upperize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123ABC.456DEF");
+
+            let result = upperize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.ABC.456.DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_tail_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_upperize() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_with_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123.456.DEF.G89.HI.JKL.MN12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "ABC.DEF.GHI.JK.LM.NO");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123.ABC456.DEF");
+
+            let result = upperize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123.ABC456.DEF");
+
+            let result = upperize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.ABC456.DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_upperize() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_with_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC.123.456.DEF.G.89.HI.JKL.MN.12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "ABC.DEF.GHI.JK.LM.NO");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123.ABC.456.DEF");
+
+            let result = upperize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123.ABC.456.DEF");
+
+            let result = upperize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.ABC.456.DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_part_of_a_word {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_upperize() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_with_digits() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123.456DEF.G89HI.JKL.MN12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "ABC.DEF.GHI.JK.LM.NO");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123ABC456DEF");
+
+            let result = upperize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123ABC456DEF");
+
+            let result = upperize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.ABC456.DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "",
+            };
+            let result = upperize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_head_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "-";
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC._DEF._GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "_";
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC.-DEF.-GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "_";
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC.-.DEF.-.GHI");
+        }
+
+        #[test]
+        fn convert_upperize() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "-";
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC._DEF._GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "_";
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC.-DEF.-GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC.123.456DEF.G.89HI.JKL.MN.12");
+
+            opts.separators = "_";
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC.123-456DEF.G.89HI.JKL.MN.12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = upperize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".ABC.~!.DEF.#.GHI.%.JK.LM.NO.?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123ABC.456DEF");
+
+            let result = upperize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123ABC.456DEF");
+
+            let result = upperize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.ABC.456.DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_tail_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "-";
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_.DEF_.GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "_";
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-.DEF-.GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "_";
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-.DEF-.GHI");
+        }
+
+        #[test]
+        fn convert_upperize() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "-";
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_.DEF_.GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "_";
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-.DEF-.GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123.456.DEF.G89.HI.JKL.MN12");
+
+            opts.separators = "_";
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123-456.DEF.G89.HI.JKL.MN12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = upperize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "..ABC~!.DEF#.GHI%.JK.LM.NO.?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123.ABC456.DEF");
+
+            let result = upperize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123.ABC456.DEF");
+
+            let result = upperize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.ABC456.DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "-";
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC._.DEF._.GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "_";
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC.-.DEF.-.GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "_";
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC.-.DEF.-.GHI");
+        }
+
+        #[test]
+        fn convert_upperize() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "-";
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC._.DEF._.GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "_";
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC.-.DEF.-.GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC.123.456.DEF.G.89.HI.JKL.MN.12");
+
+            opts.separators = "_";
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC.123-456.DEF.G.89.HI.JKL.MN.12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = upperize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "..ABC.~!.DEF.#.GHI.%.JK.LM.NO.?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123.ABC.456.DEF");
+
+            let result = upperize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123.ABC.456.DEF");
+
+            let result = upperize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.ABC.456.DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "-_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_part_of_a_word_with_separators {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "-";
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "_";
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "_";
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-.DEF-.GHI");
+        }
+
+        #[test]
+        fn convert_upperize() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "-";
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.separators = "_";
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-",
+                keep: "",
+            };
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123.456DEF.G89HI.JKL.MN12");
+
+            opts.separators = "_";
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123-456DEF.G89HI.JKL.MN12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: ":@$&()/",
+                keep: "",
+            };
+            let result = upperize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".ABC~!.DEF#.GHI%.JK.LM.NO.?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123ABC456DEF");
+
+            let result = upperize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123ABC456DEF");
+
+            let result = upperize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.ABC456.DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "-_",
+                keep: "",
+            };
+            let result = upperize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_head_of_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = upperize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = upperize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC._DEF._GHI");
+
+            opts.keep = "-";
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.keep = "-";
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC.-DEF.-GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.keep = "-";
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC.-.DEF.-.GHI");
+        }
+
+        #[test]
+        fn convert_upperize() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.keep = "_";
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC._DEF._GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.keep = "-";
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC.-DEF.-GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC.123.456DEF.G.89HI.JKL.MN.12");
+
+            opts.keep = "-";
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC.123-456DEF.G.89HI.JKL.MN.12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: ".~!#%?",
+            };
+            let result = upperize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".ABC.~!.DEF.#.GHI.%.JK.LM.NO.?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = upperize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123ABC.456DEF");
+
+            let result = upperize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123ABC.456DEF");
+
+            let result = upperize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.ABC.456.DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = upperize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_tail_of_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = upperize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = upperize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.keep = "_";
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_.DEF_.GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.keep = "-";
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-.DEF-.GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.keep = "-";
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-.DEF-.GHI");
+        }
+
+        #[test]
+        fn convert_upperize() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.keep = "_";
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_.DEF_.GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.keep = "-";
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-.DEF-.GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123.456.DEF.G89.HI.JKL.MN12");
+
+            opts.keep = "-";
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123-456.DEF.G89.HI.JKL.MN12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: ".~!#%?",
+            };
+            let result = upperize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "..ABC~!.DEF#.GHI%.JK.LM.NO.?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = upperize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123.ABC456.DEF");
+
+            let result = upperize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123.ABC456.DEF");
+
+            let result = upperize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.ABC456.DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = upperize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = upperize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = upperize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.keep = "_";
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC._.DEF._.GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.keep = "-";
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC.-.DEF.-.GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.keep = "-";
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC.-.DEF.-.GHI");
+        }
+
+        #[test]
+        fn convert_upperize() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-",
+            };
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.keep = "_";
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC._.DEF._.GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.keep = "-";
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC.-.DEF.-.GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "_",
+            };
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC.123.456.DEF.G.89.HI.JKL.MN.12");
+
+            opts.keep = "-";
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC.123-456.DEF.G.89.HI.JKL.MN.12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: ".~!#%?",
+            };
+            let result = upperize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, "..ABC.~!.DEF.#.GHI.%.JK.LM.NO.?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = upperize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123.ABC.456.DEF");
+
+            let result = upperize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123.ABC.456.DEF");
+
+            let result = upperize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.ABC.456.DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: true,
+                separate_after_non_alphabets: true,
+                separators: "",
+                keep: "-_",
+            };
+            let result = upperize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+
+    mod non_alphabets_as_part_of_a_word_with_kept_characters {
+        use super::*;
+
+        #[test]
+        fn convert_camel_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = upperize::<'.'>("abcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_pascal_case() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = upperize::<'.'>("AbcDefGHIjk", &opts);
+            assert_eq!(result, "ABC.DEF.GH.IJK");
+        }
+
+        #[test]
+        fn convert_snake_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.keep = "_";
+            let result = upperize::<'.'>("abc_def_ghi", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_kebab_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.keep = "-";
+            let result = upperize::<'.'>("abc-def-ghi", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_train_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.keep = "-";
+            let result = upperize::<'.'>("Abc-Def-Ghi", &opts);
+            assert_eq!(result, "ABC-.DEF-.GHI");
+        }
+
+        #[test]
+        fn convert_upperize() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-",
+            };
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.keep = "_";
+            let result = upperize::<'.'>("ABC_DEF_GHI", &opts);
+            assert_eq!(result, "ABC_DEF_GHI");
+        }
+
+        #[test]
+        fn convert_cobol_case() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC.DEF.GHI");
+
+            opts.keep = "-";
+            let result = upperize::<'.'>("ABC-DEF-GHI", &opts);
+            assert_eq!(result, "ABC-DEF-GHI");
+        }
+
+        #[test]
+        fn convert_with_keeping_digits() {
+            let mut opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "_",
+            };
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123.456DEF.G89HI.JKL.MN12");
+
+            opts.keep = "-";
+            let result = upperize::<'.'>("abc123-456defG89HIJklMN12", &opts);
+            assert_eq!(result, "ABC123-456DEF.G89HI.JKL.MN12");
+        }
+
+        #[test]
+        fn convert_with_symbols_as_separators() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: ".~!#%?",
+            };
+            let result = upperize::<'.'>(":.abc~!@def#$ghi%&jk(lm)no/?", &opts);
+            assert_eq!(result, ".ABC~!.DEF#.GHI%.JK.LM.NO.?");
+        }
+
+        #[test]
+        fn convert_when_starting_with_digit() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = upperize::<'.'>("123abc456def", &opts);
+            assert_eq!(result, "123ABC456DEF");
+
+            let result = upperize::<'.'>("123ABC456DEF", &opts);
+            assert_eq!(result, "123ABC456DEF");
+
+            let result = upperize::<'.'>("123Abc456Def", &opts);
+            assert_eq!(result, "123.ABC456.DEF");
+        }
+
+        #[test]
+        fn convert_empty_string() {
+            let opts = Options {
+                separate_before_non_alphabets: false,
+                separate_after_non_alphabets: false,
+                separators: "",
+                keep: "-_",
+            };
+            let result = upperize::<'.'>("", &opts);
+            assert_eq!(result, "");
+        }
+    }
+}

--- a/src/upperize.rs
+++ b/src/upperize.rs
@@ -28,9 +28,8 @@ use crate::options::Options;
 ///
 /// # Returns
 ///
-/// - **Normal Return**: Returns a [`String`] with all words uppercased and joined by
-///   `CONCATENATOR`. Returns an empty [`String`] if `input` is empty.
-/// - **Error Return**: This function is infallible and does not return a [`Result`] or panic.
+/// - Returns a [`String`] with all words uppercased and joined by `CONCATENATOR`.
+///   Returns an empty [`String`] if `input` is empty.
 ///
 /// # Examples
 ///

--- a/src/upperize.rs
+++ b/src/upperize.rs
@@ -16,6 +16,8 @@ use crate::options::Options;
 /// symbols) according to options such as `opts.separators`, `opts.keep`,
 /// `opts.separate_before_non_alphabets`, and `opts.separate_after_non_alphabets` to determine
 /// word boundaries, upperizing characters, and insert the `CONCATENATOR` character.
+/// If a character is specified in both `opts.separators` and `opts.keep`, the character in
+/// `opts.separators` takes precedence and the character in `opts.keep` is ignored.
 ///
 /// # Parameters
 ///
@@ -26,8 +28,9 @@ use crate::options::Options;
 ///
 /// # Returns
 ///
-/// - Returns a [`String`] with all words uppercased and joined by `CONCATENATOR`.
-///   Returns an empty [`String`] if `input` is empty.
+/// - **Normal Return**: Returns a [`String`] with all words uppercased and joined by
+///   `CONCATENATOR`. Returns an empty [`String`] if `input` is empty.
+/// - **Error Return**: This function is infallible and does not return a [`Result`] or panic.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
This PR introduces three new generic functions: `upperize`, `lowerize`, and `capitalize`.

Related: #39 

