### PR TITLE
refactor: renamed the constant generic parameter `CONCATENATOR` to `JOINER`

### DIFF
--- a/src/capitalize.rs
+++ b/src/capitalize.rs
@@ -5,31 +5,31 @@
 use crate::options::Options;
 
 /// A generic function that converts string cases into a capitalized format joined by a specified
-/// concatenator character.
+/// joiner character.
 ///
 /// It processes the input string `input`, identifies word boundaries based on character casing and
 /// non-alphabetic character rules defined in `opts`, capitalizes the head character of each word,
 /// lowercases subsequent letters, and joins the words using the const generic character
-/// `CONCATENATOR`.
+/// `JOINER`.
 ///
 /// It operates by iterating character by character through `input` using an internal state
 /// machine. It handles ASCII uppercase, ASCII lowercase, and non-alphabetic characters (digits and
 /// symbols) according to options such as `opts.separators`, `opts.keep`,
 /// `opts.separate_before_non_alphabets`, and `opts.separate_after_non_alphabets` to determine
-/// word boundaries, capitalize initial letters, and insert the `CONCATENATOR` character.
+/// word boundaries, capitalize initial letters, and insert the `JOINER` character.
 /// If a character is specified in both `opts.separators` and `opts.keep`, the character in
 /// `opts.separators` takes precedence and the character in `opts.keep` is ignored.
 ///
 /// # Parameters
 ///
-/// - `CONCATENATOR`: A const generic `char` used as the delimiter between capitalized words.
+/// - `JOINER`: A const generic `char` used as the joiner between capitalized words.
 /// - `input`: The target string slice (`&str`) to be capitalized.
 /// - `opts`: A reference to [`Options`] defining separator rules, retained characters, and boundary
 ///   behaviors.
 ///
 /// # Returns
 ///
-/// - Returns a [`String`] with all words capitalized and joined by `CONCATENATOR`.
+/// - Returns a [`String`] with all words capitalized and joined by `JOINER`.
 ///   Returns an empty [`String`] if `input` is empty.
 ///
 /// # Examples
@@ -46,7 +46,7 @@ use crate::options::Options;
 /// let result = capitalize::<'.'>("foo_bar_100_baz", &opts);
 /// assert_eq!(result, "Foo.Bar.100.Baz");
 /// ```
-pub fn capitalize<const CONCATENATOR: char>(input: &str, opts: &Options) -> String {
+pub fn capitalize<const JOINER: char>(input: &str, opts: &Options) -> String {
     let mut result = String::with_capacity(input.len() + input.len() / 2);
     // .len returns byte count but ok in this case!
 
@@ -74,7 +74,7 @@ pub fn capitalize<const CONCATENATOR: char>(input: &str, opts: &Options) -> Stri
                 result.push(ch.to_ascii_lowercase());
                 flag = ChIs::NextOfContdUpper;
             } else {
-                result.push(CONCATENATOR);
+                result.push(JOINER);
                 result.push(ch);
                 flag = ChIs::NextOfUpper;
             }
@@ -83,14 +83,14 @@ pub fn capitalize<const CONCATENATOR: char>(input: &str, opts: &Options) -> Stri
                 result.push(ch.to_ascii_uppercase());
             } else if flag == ChIs::NextOfContdUpper {
                 if let Some(prev) = result.pop() {
-                    result.push(CONCATENATOR);
+                    result.push(JOINER);
                     result.push(prev.to_ascii_uppercase());
                     result.push(ch);
                 }
             } else if flag == ChIs::NextOfSepMark
                 || (opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
             {
-                result.push(CONCATENATOR);
+                result.push(JOINER);
                 result.push(ch.to_ascii_uppercase());
             } else {
                 result.push(ch);
@@ -116,14 +116,14 @@ pub fn capitalize<const CONCATENATOR: char>(input: &str, opts: &Options) -> Stri
                     if flag == ChIs::FirstOfStr || flag == ChIs::NextOfKeptMark {
                         result.push(ch);
                     } else {
-                        result.push(CONCATENATOR);
+                        result.push(JOINER);
                         result.push(ch);
                     }
                 } else {
                     if flag != ChIs::NextOfSepMark {
                         result.push(ch);
                     } else {
-                        result.push(CONCATENATOR);
+                        result.push(JOINER);
                         result.push(ch);
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! This library provides some functions that convert string cases between camelCase, COBOL-CASE,
 //! kebab-case, MACRO_CASE, PascalCase, snake_case and Train-Case.
 //! In addition, generic functions `capitalize`, `lowerize`, and `upperize` are provided to convert
-//! string cases with a custom concatenator character.
+//! string cases with a custom joiner character.
 //! And this library also provides a trait `Caser` which enables strings to convert themselves
 //! to their cases by their own methods.
 //!
@@ -66,7 +66,7 @@
 //! ```
 //!
 //! You can also use the generic functions `capitalize`, `lowerize`, and `upperize` to convert
-//! strings into capitalized, lowercased, or uppercased words joined by a custom concatenator
+//! strings into capitalized, lowercased, or uppercased words joined by a custom joiner
 //! character:
 //!
 //! ```rust

--- a/src/lowerize.rs
+++ b/src/lowerize.rs
@@ -5,30 +5,30 @@
 use crate::options::Options;
 
 /// A generic function that converts string cases into a lowercased format joined by a specified
-/// concatenator character.
+/// joiner character.
 ///
 /// It processes the input string `input`, identifies word boundaries based on character casing and
 /// non-alphabetic character rules defined in `opts`, converts alphabetic characters to lowercase,
-/// and joins the words using the const generic character `CONCATENATOR`.
+/// and joins the words using the const generic character `JOINER`.
 ///
 /// It operates by iterating character by character through `input` using an internal state
 /// machine. It handles ASCII uppercase, ASCII lowercase, and non-alphabetic characters (digits and
 /// symbols) according to options such as `opts.separators`, `opts.keep`,
 /// `opts.separate_before_non_alphabets`, and `opts.separate_after_non_alphabets` to determine
-/// word boundaries, lowerizing characters, and insert the `CONCATENATOR` character.
+/// word boundaries, lowerizing characters, and insert the `JOINER` character.
 /// If a character is specified in both `opts.separators` and `opts.keep`, the character in
 /// `opts.separators` takes precedence and the character in `opts.keep` is ignored.
 ///
 /// # Parameters
 ///
-/// - `CONCATENATOR`: A const generic `char` used as the delimiter between lowercased words.
+/// - `JOINER`: A const generic `char` used as the delimiter between lowercased words.
 /// - `input`: The target string slice (`&str`) to be lowercased.
 /// - `opts`: A reference to [`Options`] defining separator rules, retained characters, and boundary
 ///   behaviors.
 ///
 /// # Returns
 ///
-/// - Returns a [`String`] with all words lowercased and joined by `CONCATENATOR`.
+/// - Returns a [`String`] with all words lowercased and joined by `JOINER`.
 ///   Returns an empty [`String`] if `input` is empty.
 ///
 /// # Examples
@@ -45,7 +45,7 @@ use crate::options::Options;
 /// let result = lowerize::<'.' >("foo_bar_100_baz", &opts);
 /// assert_eq!(result, "foo.bar.100.baz");
 /// ```
-pub fn lowerize<const CONCATENATOR: char>(input: &str, opts: &Options) -> String {
+pub fn lowerize<const JOINER: char>(input: &str, opts: &Options) -> String {
     let mut result = String::with_capacity(input.len() + input.len() / 2);
     // .len returns byte count but ok in this case!
 
@@ -73,21 +73,21 @@ pub fn lowerize<const CONCATENATOR: char>(input: &str, opts: &Options) -> String
                 result.push(ch.to_ascii_lowercase());
                 flag = ChIs::NextOfContdUpper;
             } else {
-                result.push(CONCATENATOR);
+                result.push(JOINER);
                 result.push(ch.to_ascii_lowercase());
                 flag = ChIs::NextOfUpper;
             }
         } else if ch.is_ascii_lowercase() {
             if flag == ChIs::NextOfContdUpper {
                 if let Some(prev) = result.pop() {
-                    result.push(CONCATENATOR);
+                    result.push(JOINER);
                     result.push(prev);
                     result.push(ch);
                 }
             } else if flag == ChIs::NextOfSepMark
                 || (opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
             {
-                result.push(CONCATENATOR);
+                result.push(JOINER);
                 result.push(ch);
             } else {
                 result.push(ch);
@@ -113,14 +113,14 @@ pub fn lowerize<const CONCATENATOR: char>(input: &str, opts: &Options) -> String
                     if flag == ChIs::FirstOfStr || flag == ChIs::NextOfKeptMark {
                         result.push(ch);
                     } else {
-                        result.push(CONCATENATOR);
+                        result.push(JOINER);
                         result.push(ch);
                     }
                 } else {
                     if flag != ChIs::NextOfSepMark {
                         result.push(ch);
                     } else {
-                        result.push(CONCATENATOR);
+                        result.push(JOINER);
                         result.push(ch);
                     }
                 }

--- a/src/upperize.rs
+++ b/src/upperize.rs
@@ -5,30 +5,30 @@
 use crate::options::Options;
 
 /// A generic function that converts string cases into an uppercased format joined by a specified
-/// concatenator character.
+/// joiner character.
 ///
 /// It processes the input string `input`, identifies word boundaries based on character casing and
 /// non-alphabetic character rules defined in `opts`, converts alphabetic characters to uppercase,
-/// and joins the words using the const generic character `CONCATENATOR`.
+/// and joins the words using the const generic character `JOINER`.
 ///
 /// It operates by iterating character by character through `input` using an internal state
 /// machine. It handles ASCII uppercase, ASCII lowercase, and non-alphabetic characters (digits and
 /// symbols) according to options such as `opts.separators`, `opts.keep`,
 /// `opts.separate_before_non_alphabets`, and `opts.separate_after_non_alphabets` to determine
-/// word boundaries, upperizing characters, and insert the `CONCATENATOR` character.
+/// word boundaries, upperizing characters, and insert the `JOINER` character.
 /// If a character is specified in both `opts.separators` and `opts.keep`, the character in
 /// `opts.separators` takes precedence and the character in `opts.keep` is ignored.
 ///
 /// # Parameters
 ///
-/// - `CONCATENATOR`: A const generic `char` used as the delimiter between uppercased words.
+/// - `JOINER`: A const generic `char` used as the delimiter between uppercased words.
 /// - `input`: The target string slice (`&str`) to be uppercased.
 /// - `opts`: A reference to [`Options`] defining separator rules, retained characters, and boundary
 ///   behaviors.
 ///
 /// # Returns
 ///
-/// - Returns a [`String`] with all words uppercased and joined by `CONCATENATOR`.
+/// - Returns a [`String`] with all words uppercased and joined by `JOINER`.
 ///   Returns an empty [`String`] if `input` is empty.
 ///
 /// # Examples
@@ -45,7 +45,7 @@ use crate::options::Options;
 /// let result = upperize::<'.' >("foo_bar_100_baz", &opts);
 /// assert_eq!(result, "FOO.BAR.100.BAZ");
 /// ```
-pub fn upperize<const CONCATENATOR: char>(input: &str, opts: &Options) -> String {
+pub fn upperize<const JOINER: char>(input: &str, opts: &Options) -> String {
     let mut result = String::with_capacity(input.len() + input.len() / 2);
     // .len returns byte count but ok in this case!
 
@@ -73,21 +73,21 @@ pub fn upperize<const CONCATENATOR: char>(input: &str, opts: &Options) -> String
                 result.push(ch);
                 flag = ChIs::NextOfContdUpper;
             } else {
-                result.push(CONCATENATOR);
+                result.push(JOINER);
                 result.push(ch);
                 flag = ChIs::NextOfUpper;
             }
         } else if ch.is_ascii_lowercase() {
             if flag == ChIs::NextOfContdUpper {
                 if let Some(prev) = result.pop() {
-                    result.push(CONCATENATOR);
+                    result.push(JOINER);
                     result.push(prev);
                     result.push(ch.to_ascii_uppercase());
                 }
             } else if flag == ChIs::NextOfSepMark
                 || (opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
             {
-                result.push(CONCATENATOR);
+                result.push(JOINER);
                 result.push(ch.to_ascii_uppercase());
             } else {
                 result.push(ch.to_ascii_uppercase());
@@ -113,14 +113,14 @@ pub fn upperize<const CONCATENATOR: char>(input: &str, opts: &Options) -> String
                     if flag == ChIs::FirstOfStr || flag == ChIs::NextOfKeptMark {
                         result.push(ch);
                     } else {
-                        result.push(CONCATENATOR);
+                        result.push(JOINER);
                         result.push(ch);
                     }
                 } else {
                     if flag != ChIs::NextOfSepMark {
                         result.push(ch);
                     } else {
-                        result.push(CONCATENATOR);
+                        result.push(JOINER);
                         result.push(ch);
                     }
                 }


### PR DESCRIPTION
This PR renames the parameter `CONCATENATOR` to `JOINER`.

The parameter represents the character inserted between words in the output string rather than an object that performs concatenation. The name `joiner` more accurately describes its purpose and pairs naturally with the existing `separator` parameter, which represents word separators in the input string.