### PR TITLE
update: used upperize, lowerize, and capitalize for joiner-based case conversions

### DIFF
--- a/src/cobol_case.rs
+++ b/src/cobol_case.rs
@@ -1,8 +1,9 @@
-// Copyright (C) 2024-2025 Takayuki Sato. All Rights Reserved.
+// Copyright (C) 2024-2026 Takayuki Sato. All Rights Reserved.
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
 use crate::options::Options;
+use crate::upperize::upperize;
 
 /// Converts the input string to cobol case with the specified options.
 ///
@@ -17,94 +18,7 @@ use crate::options::Options;
 ///     assert_eq!(cobol, "FOO-BAR-123-BAZ");
 /// ```
 pub fn cobol_case_with_options(input: &str, opts: &Options) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
-
-    #[derive(PartialEq)]
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeptMark,
-        Other,
-    }
-
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if ch.is_ascii_uppercase() {
-            if flag == ChIs::FirstOfStr {
-                result.push(ch);
-                flag = ChIs::NextOfUpper;
-            } else if flag == ChIs::NextOfUpper
-                || flag == ChIs::NextOfContdUpper
-                || (!opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
-            {
-                result.push(ch);
-                flag = ChIs::NextOfContdUpper;
-            } else {
-                result.push('-');
-                result.push(ch);
-                flag = ChIs::NextOfUpper;
-            }
-        } else if ch.is_ascii_lowercase() {
-            if flag == ChIs::NextOfContdUpper {
-                if let Some(prev) = result.pop() {
-                    result.push('-');
-                    result.push(prev);
-                    result.push(ch.to_ascii_uppercase());
-                }
-            } else if flag == ChIs::NextOfSepMark
-                || (opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
-            {
-                result.push('-');
-                result.push(ch.to_ascii_uppercase());
-            } else {
-                result.push(ch.to_ascii_uppercase());
-            }
-            flag = ChIs::Other;
-        } else {
-            let mut is_kept_char = false;
-            if ch.is_ascii_digit() {
-                is_kept_char = true;
-            } else if !opts.separators.is_empty() {
-                if !opts.separators.contains(ch) {
-                    is_kept_char = true;
-                }
-            } else if !opts.keep.is_empty() {
-                #[allow(clippy::collapsible_if)]
-                if opts.keep.contains(ch) {
-                    is_kept_char = true;
-                }
-            }
-
-            if is_kept_char {
-                if opts.separate_before_non_alphabets {
-                    if flag == ChIs::FirstOfStr || flag == ChIs::NextOfKeptMark {
-                        result.push(ch);
-                    } else {
-                        result.push('-');
-                        result.push(ch);
-                    }
-                } else {
-                    if flag != ChIs::NextOfSepMark {
-                        result.push(ch);
-                    } else {
-                        result.push('-');
-                        result.push(ch);
-                    }
-                }
-                flag = ChIs::NextOfKeptMark;
-            } else {
-                if flag != ChIs::FirstOfStr {
-                    flag = ChIs::NextOfSepMark;
-                }
-            }
-        }
-    }
-
-    result
+    upperize::<'-'>(input, opts)
 }
 
 /// Converts the input string to cobol case.
@@ -123,7 +37,7 @@ pub fn cobol_case(input: &str) -> String {
         separators: "",
         keep: "",
     };
-    cobol_case_with_options(input, &opts)
+    upperize::<'-'>(input, &opts)
 }
 
 /// Converts the input string to cobol case with the specified separator characters.
@@ -135,7 +49,7 @@ pub fn cobol_case_with_sep(input: &str, seps: &str) -> String {
         separators: seps,
         keep: "",
     };
-    cobol_case_with_options(input, &opts)
+    upperize::<'-'>(input, &opts)
 }
 
 /// Converts the input string to cobol case with the specified characters to be kept.
@@ -147,7 +61,7 @@ pub fn cobol_case_with_keep(input: &str, kept: &str) -> String {
         separators: "",
         keep: kept,
     };
-    cobol_case_with_options(input, &opts)
+    upperize::<'-'>(input, &opts)
 }
 
 /// Converts the input string to cobol case.
@@ -162,7 +76,7 @@ pub fn cobol_case_with_nums_as_word(input: &str) -> String {
         separators: "",
         keep: "",
     };
-    cobol_case_with_options(input, &opts)
+    upperize::<'-'>(input, &opts)
 }
 
 #[cfg(test)]

--- a/src/kebab_case.rs
+++ b/src/kebab_case.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Takayuki Sato. All Rights Reserved.
+// Copyright (C) 2024-2026 Takayuki Sato. All Rights Reserved.
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 

--- a/src/kebab_case.rs
+++ b/src/kebab_case.rs
@@ -2,6 +2,7 @@
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
+use crate::lowerize::lowerize;
 use crate::options::Options;
 
 /// Converts the input string to kebab case with the specified options.
@@ -17,94 +18,7 @@ use crate::options::Options;
 ///     assert_eq!(kebab, "foo-bar-123-baz");
 /// ```
 pub fn kebab_case_with_options(input: &str, opts: &Options) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
-
-    #[derive(PartialEq)]
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeptMark,
-        Other,
-    }
-
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if ch.is_ascii_uppercase() {
-            if flag == ChIs::FirstOfStr {
-                result.push(ch.to_ascii_lowercase());
-                flag = ChIs::NextOfUpper;
-            } else if flag == ChIs::NextOfUpper
-                || flag == ChIs::NextOfContdUpper
-                || (!opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
-            {
-                result.push(ch.to_ascii_lowercase());
-                flag = ChIs::NextOfContdUpper;
-            } else {
-                result.push('-');
-                result.push(ch.to_ascii_lowercase());
-                flag = ChIs::NextOfUpper;
-            }
-        } else if ch.is_ascii_lowercase() {
-            if flag == ChIs::NextOfContdUpper {
-                if let Some(prev) = result.pop() {
-                    result.push('-');
-                    result.push(prev);
-                    result.push(ch);
-                }
-            } else if flag == ChIs::NextOfSepMark
-                || (opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
-            {
-                result.push('-');
-                result.push(ch);
-            } else {
-                result.push(ch);
-            }
-            flag = ChIs::Other;
-        } else {
-            let mut is_kept_char = false;
-            if ch.is_ascii_digit() {
-                is_kept_char = true;
-            } else if !opts.separators.is_empty() {
-                if !opts.separators.contains(ch) {
-                    is_kept_char = true;
-                }
-            } else if !opts.keep.is_empty() {
-                #[allow(clippy::collapsible_if)]
-                if opts.keep.contains(ch) {
-                    is_kept_char = true;
-                }
-            }
-
-            if is_kept_char {
-                if opts.separate_before_non_alphabets {
-                    if flag == ChIs::FirstOfStr || flag == ChIs::NextOfKeptMark {
-                        result.push(ch);
-                    } else {
-                        result.push('-');
-                        result.push(ch);
-                    }
-                } else {
-                    if flag != ChIs::NextOfSepMark {
-                        result.push(ch);
-                    } else {
-                        result.push('-');
-                        result.push(ch);
-                    }
-                }
-                flag = ChIs::NextOfKeptMark;
-            } else {
-                if flag != ChIs::FirstOfStr {
-                    flag = ChIs::NextOfSepMark;
-                }
-            }
-        }
-    }
-
-    result
+    lowerize::<'-'>(input, opts)
 }
 
 /// Converts the input string to kebab case.
@@ -123,7 +37,7 @@ pub fn kebab_case(input: &str) -> String {
         separators: "",
         keep: "",
     };
-    kebab_case_with_options(input, &opts)
+    lowerize::<'-'>(input, &opts)
 }
 
 /// Converts the input string to kebab case with the specified separator characters.
@@ -135,7 +49,7 @@ pub fn kebab_case_with_sep(input: &str, seps: &str) -> String {
         separators: seps,
         keep: "",
     };
-    kebab_case_with_options(input, &opts)
+    lowerize::<'-'>(input, &opts)
 }
 
 /// Converts the input string to kebab case with the specified characters to be kept.
@@ -147,7 +61,7 @@ pub fn kebab_case_with_keep(input: &str, kept: &str) -> String {
         separators: "",
         keep: kept,
     };
-    kebab_case_with_options(input, &opts)
+    lowerize::<'-'>(input, &opts)
 }
 
 /// Converts the input string to kebab case.
@@ -162,7 +76,7 @@ pub fn kebab_case_with_nums_as_word(input: &str) -> String {
         separators: "",
         keep: "",
     };
-    kebab_case_with_options(input, &opts)
+    lowerize::<'-'>(input, &opts)
 }
 
 #[cfg(test)]

--- a/src/macro_case.rs
+++ b/src/macro_case.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Takayuki Sato. All Rights Reserved.
+// Copyright (C) 2024-2026 Takayuki Sato. All Rights Reserved.
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 

--- a/src/macro_case.rs
+++ b/src/macro_case.rs
@@ -3,6 +3,7 @@
 // See the file LICENSE in this distribution for more details.
 
 use crate::options::Options;
+use crate::upperize::upperize;
 
 /// Converts the input string to macro case with the specified options.
 ///
@@ -17,94 +18,7 @@ use crate::options::Options;
 ///     assert_eq!(result, "FOO_BAR_123_BAZ");
 /// ```
 pub fn macro_case_with_options(input: &str, opts: &Options) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
-
-    #[derive(PartialEq)]
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeptMark,
-        Other,
-    }
-
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if ch.is_ascii_uppercase() {
-            if flag == ChIs::FirstOfStr {
-                result.push(ch);
-                flag = ChIs::NextOfUpper;
-            } else if flag == ChIs::NextOfUpper
-                || flag == ChIs::NextOfContdUpper
-                || (!opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
-            {
-                result.push(ch);
-                flag = ChIs::NextOfContdUpper;
-            } else {
-                result.push('_');
-                result.push(ch);
-                flag = ChIs::NextOfUpper;
-            }
-        } else if ch.is_ascii_lowercase() {
-            if flag == ChIs::NextOfContdUpper {
-                if let Some(prev) = result.pop() {
-                    result.push('_');
-                    result.push(prev);
-                    result.push(ch.to_ascii_uppercase());
-                }
-            } else if flag == ChIs::NextOfSepMark
-                || (opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
-            {
-                result.push('_');
-                result.push(ch.to_ascii_uppercase());
-            } else {
-                result.push(ch.to_ascii_uppercase());
-            }
-            flag = ChIs::Other;
-        } else {
-            let mut is_kept_char = false;
-            if ch.is_ascii_digit() {
-                is_kept_char = true;
-            } else if !opts.separators.is_empty() {
-                if !opts.separators.contains(ch) {
-                    is_kept_char = true;
-                }
-            } else if !opts.keep.is_empty() {
-                #[allow(clippy::collapsible_if)]
-                if opts.keep.contains(ch) {
-                    is_kept_char = true;
-                }
-            }
-
-            if is_kept_char {
-                if opts.separate_before_non_alphabets {
-                    if flag == ChIs::FirstOfStr || flag == ChIs::NextOfKeptMark {
-                        result.push(ch);
-                    } else {
-                        result.push('_');
-                        result.push(ch);
-                    }
-                } else {
-                    if flag != ChIs::NextOfSepMark {
-                        result.push(ch);
-                    } else {
-                        result.push('_');
-                        result.push(ch);
-                    }
-                }
-                flag = ChIs::NextOfKeptMark;
-            } else {
-                if flag != ChIs::FirstOfStr {
-                    flag = ChIs::NextOfSepMark;
-                }
-            }
-        }
-    }
-
-    result
+    upperize::<'_'>(input, opts)
 }
 
 /// Converts the input string to macro case.
@@ -123,7 +37,7 @@ pub fn macro_case(input: &str) -> String {
         separators: "",
         keep: "",
     };
-    macro_case_with_options(input, &opts)
+    upperize::<'_'>(input, &opts)
 }
 
 /// Converts the input string to macro case with the specified separator characters.
@@ -135,7 +49,7 @@ pub fn macro_case_with_sep(input: &str, seps: &str) -> String {
         separators: seps,
         keep: "",
     };
-    macro_case_with_options(input, &opts)
+    upperize::<'_'>(input, &opts)
 }
 
 /// Converts the input string to macro case with the specified characters to be kept.
@@ -147,7 +61,7 @@ pub fn macro_case_with_keep(input: &str, kept: &str) -> String {
         separators: "",
         keep: kept,
     };
-    macro_case_with_options(input, &opts)
+    upperize::<'_'>(input, &opts)
 }
 
 /// Converts the input string to macro case.
@@ -162,7 +76,7 @@ pub fn macro_case_with_nums_as_word(input: &str) -> String {
         separators: "",
         keep: "",
     };
-    macro_case_with_options(input, &opts)
+    upperize::<'_'>(input, &opts)
 }
 
 #[cfg(test)]

--- a/src/snake_case.rs
+++ b/src/snake_case.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Takayuki Sato. All Rights Reserved.
+// Copyright (C) 2024-2026 Takayuki Sato. All Rights Reserved.
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 

--- a/src/snake_case.rs
+++ b/src/snake_case.rs
@@ -2,6 +2,7 @@
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
+use crate::lowerize::lowerize;
 use crate::options::Options;
 
 /// Converts the input string to snake case with the specified options.
@@ -17,94 +18,7 @@ use crate::options::Options;
 ///     assert_eq!(snake, "foo_bar_123_baz");
 /// ```
 pub fn snake_case_with_options(input: &str, opts: &Options) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
-
-    #[derive(PartialEq)]
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeptMark,
-        Other,
-    }
-
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if ch.is_ascii_uppercase() {
-            if flag == ChIs::FirstOfStr {
-                result.push(ch.to_ascii_lowercase());
-                flag = ChIs::NextOfUpper;
-            } else if flag == ChIs::NextOfUpper
-                || flag == ChIs::NextOfContdUpper
-                || (!opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
-            {
-                result.push(ch.to_ascii_lowercase());
-                flag = ChIs::NextOfContdUpper;
-            } else {
-                result.push('_');
-                result.push(ch.to_ascii_lowercase());
-                flag = ChIs::NextOfUpper;
-            }
-        } else if ch.is_ascii_lowercase() {
-            if flag == ChIs::NextOfContdUpper {
-                if let Some(prev) = result.pop() {
-                    result.push('_');
-                    result.push(prev);
-                    result.push(ch);
-                }
-            } else if flag == ChIs::NextOfSepMark
-                || (opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
-            {
-                result.push('_');
-                result.push(ch);
-            } else {
-                result.push(ch);
-            }
-            flag = ChIs::Other;
-        } else {
-            let mut is_kept_char = false;
-            if ch.is_ascii_digit() {
-                is_kept_char = true;
-            } else if !opts.separators.is_empty() {
-                if !opts.separators.contains(ch) {
-                    is_kept_char = true;
-                }
-            } else if !opts.keep.is_empty() {
-                #[allow(clippy::collapsible_if)]
-                if opts.keep.contains(ch) {
-                    is_kept_char = true;
-                }
-            }
-
-            if is_kept_char {
-                if opts.separate_before_non_alphabets {
-                    if flag == ChIs::FirstOfStr || flag == ChIs::NextOfKeptMark {
-                        result.push(ch);
-                    } else {
-                        result.push('_');
-                        result.push(ch);
-                    }
-                } else {
-                    if flag != ChIs::NextOfSepMark {
-                        result.push(ch);
-                    } else {
-                        result.push('_');
-                        result.push(ch);
-                    }
-                }
-                flag = ChIs::NextOfKeptMark;
-            } else {
-                if flag != ChIs::FirstOfStr {
-                    flag = ChIs::NextOfSepMark;
-                }
-            }
-        }
-    }
-
-    result
+    lowerize::<'_'>(input, opts)
 }
 
 /// Converts the input string to snake case.
@@ -123,7 +37,7 @@ pub fn snake_case(input: &str) -> String {
         separators: "",
         keep: "",
     };
-    snake_case_with_options(input, &opts)
+    lowerize::<'_'>(input, &opts)
 }
 
 /// Converts the input string to snake case with the specified separator characters.
@@ -135,7 +49,7 @@ pub fn snake_case_with_sep(input: &str, seps: &str) -> String {
         separators: seps,
         keep: "",
     };
-    snake_case_with_options(input, &opts)
+    lowerize::<'_'>(input, &opts)
 }
 
 /// Converts the input string to snake case with the specified characters to be kept.
@@ -147,7 +61,7 @@ pub fn snake_case_with_keep(input: &str, kept: &str) -> String {
         separators: "",
         keep: kept,
     };
-    snake_case_with_options(input, &opts)
+    lowerize::<'_'>(input, &opts)
 }
 
 /// Converts the input string to snake case.
@@ -162,7 +76,7 @@ pub fn snake_case_with_nums_as_word(input: &str) -> String {
         separators: "",
         keep: "",
     };
-    snake_case_with_options(input, &opts)
+    lowerize::<'_'>(input, &opts)
 }
 
 #[cfg(test)]

--- a/src/train_case.rs
+++ b/src/train_case.rs
@@ -2,6 +2,7 @@
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
+use crate::capitalize::capitalize;
 use crate::options::Options;
 
 /// Converts the input string to train case with the specified options.
@@ -17,96 +18,7 @@ use crate::options::Options;
 ///     assert_eq!(train, "Foo-Bar-123-Baz");
 /// ```
 pub fn train_case_with_options(input: &str, opts: &Options) -> String {
-    let mut result = String::with_capacity(input.len() + input.len() / 2);
-    // .len returns byte count but ok in this case!
-
-    #[derive(PartialEq)]
-    enum ChIs {
-        FirstOfStr,
-        NextOfUpper,
-        NextOfContdUpper,
-        NextOfSepMark,
-        NextOfKeptMark,
-        Other,
-    }
-
-    let mut flag = ChIs::FirstOfStr;
-
-    for ch in input.chars() {
-        if ch.is_ascii_uppercase() {
-            if flag == ChIs::FirstOfStr {
-                result.push(ch);
-                flag = ChIs::NextOfUpper;
-            } else if flag == ChIs::NextOfUpper
-                || flag == ChIs::NextOfContdUpper
-                || (!opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
-            {
-                result.push(ch.to_ascii_lowercase());
-                flag = ChIs::NextOfContdUpper;
-            } else {
-                result.push('-');
-                result.push(ch);
-                flag = ChIs::NextOfUpper;
-            }
-        } else if ch.is_ascii_lowercase() {
-            if flag == ChIs::FirstOfStr {
-                result.push(ch.to_ascii_uppercase());
-            } else if flag == ChIs::NextOfContdUpper {
-                if let Some(prev) = result.pop() {
-                    result.push('-');
-                    result.push(prev.to_ascii_uppercase());
-                    result.push(ch);
-                }
-            } else if flag == ChIs::NextOfSepMark
-                || (opts.separate_after_non_alphabets && flag == ChIs::NextOfKeptMark)
-            {
-                result.push('-');
-                result.push(ch.to_ascii_uppercase());
-            } else {
-                result.push(ch);
-            }
-            flag = ChIs::Other;
-        } else {
-            let mut is_kept_char = false;
-            if ch.is_ascii_digit() {
-                is_kept_char = true;
-            } else if !opts.separators.is_empty() {
-                if !opts.separators.contains(ch) {
-                    is_kept_char = true;
-                }
-            } else if !opts.keep.is_empty() {
-                #[allow(clippy::collapsible_if)]
-                if opts.keep.contains(ch) {
-                    is_kept_char = true;
-                }
-            }
-
-            if is_kept_char {
-                if opts.separate_before_non_alphabets {
-                    if flag == ChIs::FirstOfStr || flag == ChIs::NextOfKeptMark {
-                        result.push(ch);
-                    } else {
-                        result.push('-');
-                        result.push(ch);
-                    }
-                } else {
-                    if flag != ChIs::NextOfSepMark {
-                        result.push(ch);
-                    } else {
-                        result.push('-');
-                        result.push(ch);
-                    }
-                }
-                flag = ChIs::NextOfKeptMark;
-            } else {
-                if flag != ChIs::FirstOfStr {
-                    flag = ChIs::NextOfSepMark;
-                }
-            }
-        }
-    }
-
-    result
+    capitalize::<'-'>(input, opts)
 }
 
 /// Converts the input string to train case.
@@ -125,7 +37,7 @@ pub fn train_case(input: &str) -> String {
         separators: "",
         keep: "",
     };
-    train_case_with_options(input, &opts)
+    capitalize::<'-'>(input, &opts)
 }
 
 /// Converts the input string to train case with the specified separator characters.
@@ -137,7 +49,7 @@ pub fn train_case_with_sep(input: &str, seps: &str) -> String {
         separators: seps,
         keep: "",
     };
-    train_case_with_options(input, &opts)
+    capitalize::<'-'>(input, &opts)
 }
 
 /// Converts the input string to train case with the specified characters to be kept.
@@ -149,7 +61,7 @@ pub fn train_case_with_keep(input: &str, kept: &str) -> String {
         separators: "",
         keep: kept,
     };
-    train_case_with_options(input, &opts)
+    capitalize::<'-'>(input, &opts)
 }
 
 /// Converts the input string to train case.
@@ -164,7 +76,7 @@ pub fn train_case_with_nums_as_word(input: &str) -> String {
         separators: "",
         keep: "",
     };
-    train_case_with_options(input, &opts)
+    capitalize::<'-'>(input, &opts)
 }
 
 #[cfg(test)]

--- a/src/train_case.rs
+++ b/src/train_case.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Takayuki Sato. All Rights Reserved.
+// Copyright (C) 2024-2026 Takayuki Sato. All Rights Reserved.
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 


### PR DESCRIPTION
Closes #39 

This PR changes each case conversion function to use the `upperize`, `lowerize`, or `capitalize` functions.

However, `camel_case` and `pascal_case` are left unchanged because `upperize`, `lowerize`, and `capitalize` require a joiner character to be specified, while those two functions do not use a joiner character.

#### Caller functions

- `upperize`
    - `COBOL-CASE`
    - `MACRO_CASE`
- `lowerize`
    - `kebab-case`
    - `snake_case`
- `capitalize`
    - `Train-Case`