### PR TITLE
doc: hid deprecated functions from the API documentation

### DIFF
--- a/src/camel_case.rs
+++ b/src/camel_case.rs
@@ -107,6 +107,7 @@ pub fn camel_case(input: &str) -> String {
 }
 
 /// Converts the input string to camel case with the specified separator characters.
+#[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use camel_case_with_options instead")]
 #[inline(always)]
 pub fn camel_case_with_sep(input: &str, seps: &str) -> String {
@@ -120,6 +121,7 @@ pub fn camel_case_with_sep(input: &str, seps: &str) -> String {
 }
 
 /// Converts the input string to camel case with the specified characters to be kept.
+#[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use camel_case_with_options instead")]
 #[inline(always)]
 pub fn camel_case_with_keep(input: &str, kept: &str) -> String {

--- a/src/cobol_case.rs
+++ b/src/cobol_case.rs
@@ -43,6 +43,7 @@ pub fn cobol_case(input: &str) -> String {
 }
 
 /// Converts the input string to cobol case with the specified separator characters.
+#[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use cobol_case_with_options instead")]
 #[inline(always)]
 pub fn cobol_case_with_sep(input: &str, seps: &str) -> String {
@@ -56,6 +57,7 @@ pub fn cobol_case_with_sep(input: &str, seps: &str) -> String {
 }
 
 /// Converts the input string to cobol case with the specified characters to be kept.
+#[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use cobol_case_with_options instead")]
 #[inline(always)]
 pub fn cobol_case_with_keep(input: &str, kept: &str) -> String {
@@ -72,6 +74,7 @@ pub fn cobol_case_with_keep(input: &str, kept: &str) -> String {
 ///
 /// It treats the beginning and the end of a sequence of non-alphabetical characters as a word
 /// boundary.
+#[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use cobol_case_with_options instead")]
 #[inline(always)]
 pub fn cobol_case_with_nums_as_word(input: &str) -> String {

--- a/src/kebab_case.rs
+++ b/src/kebab_case.rs
@@ -43,6 +43,7 @@ pub fn kebab_case(input: &str) -> String {
 }
 
 /// Converts the input string to kebab case with the specified separator characters.
+#[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use kebab_case_with_options instead")]
 #[inline(always)]
 pub fn kebab_case_with_sep(input: &str, seps: &str) -> String {
@@ -56,6 +57,7 @@ pub fn kebab_case_with_sep(input: &str, seps: &str) -> String {
 }
 
 /// Converts the input string to kebab case with the specified characters to be kept.
+#[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use kebab_case_with_options instead")]
 #[inline(always)]
 pub fn kebab_case_with_keep(input: &str, kept: &str) -> String {
@@ -72,6 +74,7 @@ pub fn kebab_case_with_keep(input: &str, kept: &str) -> String {
 ///
 /// It treats the beginning and the end of a sequence of non-alphabetical characters as a word
 /// boundary.
+#[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use kebab_case_with_options instead")]
 #[inline(always)]
 pub fn kebab_case_with_nums_as_word(input: &str) -> String {

--- a/src/macro_case.rs
+++ b/src/macro_case.rs
@@ -43,6 +43,7 @@ pub fn macro_case(input: &str) -> String {
 }
 
 /// Converts the input string to macro case with the specified separator characters.
+#[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use macro_case_with_options instead")]
 #[inline(always)]
 pub fn macro_case_with_sep(input: &str, seps: &str) -> String {
@@ -56,6 +57,7 @@ pub fn macro_case_with_sep(input: &str, seps: &str) -> String {
 }
 
 /// Converts the input string to macro case with the specified characters to be kept.
+#[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use macro_case_with_options instead")]
 #[inline(always)]
 pub fn macro_case_with_keep(input: &str, kept: &str) -> String {
@@ -72,6 +74,7 @@ pub fn macro_case_with_keep(input: &str, kept: &str) -> String {
 ///
 /// It treats the beginning and the end of a sequence of non-alphabetical characters as a word
 /// boundary.
+#[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use macro_case_with_options instead")]
 #[inline(always)]
 pub fn macro_case_with_nums_as_word(input: &str) -> String {

--- a/src/pascal_case.rs
+++ b/src/pascal_case.rs
@@ -105,6 +105,7 @@ pub fn pascal_case(input: &str) -> String {
 }
 
 /// Converts the input string to pascal case with the specified separator characters.
+#[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use pascal_case_with_options instead")]
 #[inline(always)]
 pub fn pascal_case_with_sep(input: &str, seps: &str) -> String {
@@ -118,6 +119,7 @@ pub fn pascal_case_with_sep(input: &str, seps: &str) -> String {
 }
 
 /// Converts the input string to pascal case with the specified characters to be kept.
+#[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use pascal_case_with_options instead")]
 #[inline(always)]
 pub fn pascal_case_with_keep(input: &str, kept: &str) -> String {

--- a/src/snake_case.rs
+++ b/src/snake_case.rs
@@ -43,6 +43,7 @@ pub fn snake_case(input: &str) -> String {
 }
 
 /// Converts the input string to snake case with the specified separator characters.
+#[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use snake_case_with_options instead")]
 #[inline(always)]
 pub fn snake_case_with_sep(input: &str, seps: &str) -> String {
@@ -56,6 +57,7 @@ pub fn snake_case_with_sep(input: &str, seps: &str) -> String {
 }
 
 /// Converts the input string to snake case with the specified characters to be kept.
+#[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use snake_case_with_options instead")]
 #[inline(always)]
 pub fn snake_case_with_keep(input: &str, kept: &str) -> String {
@@ -72,6 +74,7 @@ pub fn snake_case_with_keep(input: &str, kept: &str) -> String {
 ///
 /// It treats the beginning and the end of a sequence of non-alphabetical characters as a word
 /// boundary.
+#[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use snake_case_with_options instead")]
 #[inline(always)]
 pub fn snake_case_with_nums_as_word(input: &str) -> String {

--- a/src/train_case.rs
+++ b/src/train_case.rs
@@ -43,6 +43,7 @@ pub fn train_case(input: &str) -> String {
 }
 
 /// Converts the input string to train case with the specified separator characters.
+#[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use train_case_with_options instead")]
 #[inline(always)]
 pub fn train_case_with_sep(input: &str, seps: &str) -> String {
@@ -56,6 +57,7 @@ pub fn train_case_with_sep(input: &str, seps: &str) -> String {
 }
 
 /// Converts the input string to train case with the specified characters to be kept.
+#[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use train_case_with_options instead")]
 #[inline(always)]
 pub fn train_case_with_keep(input: &str, kept: &str) -> String {
@@ -72,6 +74,7 @@ pub fn train_case_with_keep(input: &str, kept: &str) -> String {
 ///
 /// It treats the beginning and the end of a sequence of non-alphabetical characters as a word
 /// boundary.
+#[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use train_case_with_options instead")]
 #[inline(always)]
 pub fn train_case_with_nums_as_word(input: &str) -> String {


### PR DESCRIPTION
This PR hides deprecated functions from the API documentation by applying `#[doc(hidden)]`.

These functions remain available for backward compatibility, but they are no longer shown in the generated API documentation. This helps direct users toward the recommended APIs while reducing clutter in the documentation.
