### PR TITLE
comment,doc: fixed typos and inconsistencies in several comments

### DIFF
--- a/src/ada_case.rs
+++ b/src/ada_case.rs
@@ -24,7 +24,7 @@ pub fn ada_case_with_options(input: &str, opts: &Options) -> String {
 
 /// Converts the input string to Ada case.
 ///
-/// It treats the end of a sequence of non-alphabetical characters as a word boundary, but not
+/// It treats the end of a sequence of non-alphabetic characters as a word boundary, but not
 /// the beginning.
 ///
 /// ```rust

--- a/src/camel_case.rs
+++ b/src/camel_case.rs
@@ -88,7 +88,7 @@ pub fn camel_case_with_options(input: &str, opts: &Options) -> String {
 
 /// Converts the input string to camel case.
 ///
-/// It treats the end of a sequence of non-alphabetical characters as a word boundary, but not
+/// It treats the end of a sequence of non-alphabetic characters as a word boundary, but not
 /// the beginning.
 ///
 /// ```rust

--- a/src/caser.rs
+++ b/src/caser.rs
@@ -14,14 +14,14 @@ use crate::train_case::*;
 /// `Caser` is the trait to attach methods for converting strings `&str` and
 /// `String` to various cases.
 ///
-/// By declarating this trait with `use` keyword, all conversion methods
+/// By declaring this trait with `use` keyword, all conversion methods
 /// provided by this library become available for `&str` and `String`.
 pub trait Caser<T: AsRef<str>> {
     // camel case
 
     /// Converts the input string to camel case.
     ///
-    /// It treats the end of a sequence of non-alphabetical characters as a word boundary,
+    /// It treats the end of a sequence of non-alphabetic characters as a word boundary,
     /// but not the beginning.
     ///
     /// ```rust
@@ -64,7 +64,7 @@ pub trait Caser<T: AsRef<str>> {
 
     /// Converts the input string to cobol case.
     ///
-    /// It treats the end of a sequence of non-alphabetical characters as a word boundary,
+    /// It treats the end of a sequence of non-alphabetic characters as a word boundary,
     /// but not the beginning.
     ///
     /// ```rust
@@ -93,7 +93,7 @@ pub trait Caser<T: AsRef<str>> {
 
     /// Converts the input string to cobol case.
     ///
-    /// It treats the begin and the end of a sequence of non-alphabetical characters as a word
+    /// It treats the begin and the end of a sequence of non-alphabetic characters as a word
     /// boundary.
     #[deprecated(
         since = "0.4.0",
@@ -119,7 +119,7 @@ pub trait Caser<T: AsRef<str>> {
 
     /// Converts the input string to kebab case.
     ///
-    /// It treats the end of a sequence of non-alphabetical characters as a word boundary,
+    /// It treats the end of a sequence of non-alphabetic characters as a word boundary,
     /// but not the beginning.
     ///
     /// ```rust
@@ -148,7 +148,7 @@ pub trait Caser<T: AsRef<str>> {
 
     /// Converts the input string to kebab case.
     ///
-    /// It treats the begin and the end of a sequence of non-alphabetical characters as a word
+    /// It treats the begin and the end of a sequence of non-alphabetic characters as a word
     /// boundary.
     #[deprecated(
         since = "0.4.0",
@@ -174,7 +174,7 @@ pub trait Caser<T: AsRef<str>> {
 
     /// Converts the input string to macro case.
     ///
-    /// It treats the end of a sequence of non-alphabetical characters as a word boundary,
+    /// It treats the end of a sequence of non-alphabetic characters as a word boundary,
     /// but not the beginning.
     ///
     /// ```rust
@@ -203,7 +203,7 @@ pub trait Caser<T: AsRef<str>> {
 
     /// Converts the input string to macro case.
     ///
-    /// It treats the begin and the end of a sequence of non-alphabetical characters as a word
+    /// It treats the begin and the end of a sequence of non-alphabetic characters as a word
     /// boundary.
     #[deprecated(
         since = "0.4.0",
@@ -229,7 +229,7 @@ pub trait Caser<T: AsRef<str>> {
 
     /// Converts the input string to pascal case.
     ///
-    /// It treats the end of a sequence of non-alphabetical characters as a word boundary,
+    /// It treats the end of a sequence of non-alphabetic characters as a word boundary,
     /// but not the beginning.
     ///
     /// ```rust
@@ -274,7 +274,7 @@ pub trait Caser<T: AsRef<str>> {
 
     /// Converts the input string to snake case.
     ///
-    /// It treats the end of a sequence of non-alphabetical characters as a word boundary,
+    /// It treats the end of a sequence of non-alphabetic characters as a word boundary,
     /// but not the beginning.
     ///
     /// ```rust
@@ -303,7 +303,7 @@ pub trait Caser<T: AsRef<str>> {
 
     /// Converts the input string to snake case.
     ///
-    /// It treats the begin and the end of a sequence of non-alphabetical characters as a word
+    /// It treats the begin and the end of a sequence of non-alphabetic characters as a word
     /// boundary.
     #[deprecated(
         since = "0.4.0",
@@ -329,7 +329,7 @@ pub trait Caser<T: AsRef<str>> {
 
     /// Converts the input string to train case.
     ///
-    /// It treats the end of a sequence of non-alphabetical characters as a word boundary,
+    /// It treats the end of a sequence of non-alphabetic characters as a word boundary,
     /// but not the beginning.
     ///
     /// ```rust
@@ -358,7 +358,7 @@ pub trait Caser<T: AsRef<str>> {
 
     /// Converts the input string to train case.
     ///
-    /// It treats the begin and the end of a sequence of non-alphabetical characters as a word
+    /// It treats the begin and the end of a sequence of non-alphabetic characters as a word
     /// boundary.
     #[deprecated(
         since = "0.4.0",

--- a/src/cobol_case.rs
+++ b/src/cobol_case.rs
@@ -24,7 +24,7 @@ pub fn cobol_case_with_options(input: &str, opts: &Options) -> String {
 
 /// Converts the input string to cobol case.
 ///
-/// It treats the end of a sequence of non-alphabetical characters as a word boundary, but not
+/// It treats the end of a sequence of non-alphabetic characters as a word boundary, but not
 /// the beginning.
 ///
 /// ```rust
@@ -72,7 +72,7 @@ pub fn cobol_case_with_keep(input: &str, kept: &str) -> String {
 
 /// Converts the input string to cobol case.
 ///
-/// It treats the beginning and the end of a sequence of non-alphabetical characters as a word
+/// It treats the beginning and the end of a sequence of non-alphabetic characters as a word
 /// boundary.
 #[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use cobol_case_with_options instead")]

--- a/src/kebab_case.rs
+++ b/src/kebab_case.rs
@@ -24,7 +24,7 @@ pub fn kebab_case_with_options(input: &str, opts: &Options) -> String {
 
 /// Converts the input string to kebab case.
 ///
-/// It treats the end of a sequence of non-alphabetical characters as a word boundary, but not
+/// It treats the end of a sequence of non-alphabetic characters as a word boundary, but not
 /// the beginning.
 ///
 /// ```rust
@@ -72,7 +72,7 @@ pub fn kebab_case_with_keep(input: &str, kept: &str) -> String {
 
 /// Converts the input string to kebab case.
 ///
-/// It treats the beginning and the end of a sequence of non-alphabetical characters as a word
+/// It treats the beginning and the end of a sequence of non-alphabetic characters as a word
 /// boundary.
 #[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use kebab_case_with_options instead")]

--- a/src/macro_case.rs
+++ b/src/macro_case.rs
@@ -24,7 +24,7 @@ pub fn macro_case_with_options(input: &str, opts: &Options) -> String {
 
 /// Converts the input string to macro case.
 ///
-/// It treats the end of a sequence of non-alphabetical characters as a word boundary, but not
+/// It treats the end of a sequence of non-alphabetic characters as a word boundary, but not
 /// the beginning.
 ///
 /// ```rust
@@ -72,7 +72,7 @@ pub fn macro_case_with_keep(input: &str, kept: &str) -> String {
 
 /// Converts the input string to macro case.
 ///
-/// It treats the beginning and the end of a sequence of non-alphabetical characters as a word
+/// It treats the beginning and the end of a sequence of non-alphabetic characters as a word
 /// boundary.
 #[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use macro_case_with_options instead")]

--- a/src/options.rs
+++ b/src/options.rs
@@ -2,7 +2,7 @@
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
-/// Is a struct that represents options for case conversion of strings.
+/// A struct that represents options for case conversion of strings.
 ///
 /// The `separate_before_non_alphabets` field specifies whether to treat the
 /// beginning of a sequence of non-alphabetic characters as a word boundary.
@@ -16,9 +16,6 @@
 /// Alphanumeric characters specified in `separators` and `keep` are ignored.
 /// If both `separators` and `keep` are specified, `separators` takes precedence
 /// and `keep` is ignored.
-///
-/// If a character is specified in both `separators` and `keep`, the character in
-/// `separators` takes precedence and the character in `keep` is ignored.
 pub struct Options<'a> {
     /// Specifies whether to treat the beginning of a sequence of non-alphabetic
     /// characters as a word boundary.

--- a/src/pascal_case.rs
+++ b/src/pascal_case.rs
@@ -86,7 +86,7 @@ pub fn pascal_case_with_options(input: &str, opts: &Options) -> String {
 
 /// Converts the input string to pascal case.
 ///
-/// It treats the end of a sequence of non-alphabetical characters as a word boundary, but not
+/// It treats the end of a sequence of non-alphabetic characters as a word boundary, but not
 /// the beginning.
 ///
 /// ```rust

--- a/src/snake_case.rs
+++ b/src/snake_case.rs
@@ -24,7 +24,7 @@ pub fn snake_case_with_options(input: &str, opts: &Options) -> String {
 
 /// Converts the input string to snake case.
 ///
-/// It treats the end of a sequence of non-alphabetical characters as a word boundary, but not
+/// It treats the end of a sequence of non-alphabetic characters as a word boundary, but not
 /// the beginning.
 ///
 /// ```rust
@@ -72,7 +72,7 @@ pub fn snake_case_with_keep(input: &str, kept: &str) -> String {
 
 /// Converts the input string to snake case.
 ///
-/// It treats the beginning and the end of a sequence of non-alphabetical characters as a word
+/// It treats the beginning and the end of a sequence of non-alphabetic characters as a word
 /// boundary.
 #[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use snake_case_with_options instead")]

--- a/src/title_case.rs
+++ b/src/title_case.rs
@@ -24,7 +24,7 @@ pub fn title_case_with_options(input: &str, opts: &Options) -> String {
 
 /// Converts the input string to title case.
 ///
-/// It treats the end of a sequence of non-alphabetical characters as a word boundary, but not
+/// It treats the end of a sequence of non-alphabetic characters as a word boundary, but not
 /// the beginning.
 ///
 /// ```rust

--- a/src/train_case.rs
+++ b/src/train_case.rs
@@ -24,7 +24,7 @@ pub fn train_case_with_options(input: &str, opts: &Options) -> String {
 
 /// Converts the input string to train case.
 ///
-/// It treats the end of a sequence of non-alphabetical characters as a word boundary, but not
+/// It treats the end of a sequence of non-alphabetic characters as a word boundary, but not
 /// the beginning.
 ///
 /// ```rust
@@ -72,7 +72,7 @@ pub fn train_case_with_keep(input: &str, kept: &str) -> String {
 
 /// Converts the input string to train case.
 ///
-/// It treats the beginning and the end of a sequence of non-alphabetical characters as a word
+/// It treats the beginning and the end of a sequence of non-alphabetic characters as a word
 /// boundary.
 #[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Should use train_case_with_options instead")]


### PR DESCRIPTION
This PR fixes typos and inconsistencies in several comments. It also removes a comment added in #56, as it was redundant with the content directly above it.